### PR TITLE
add 'default route' toggle to network interface configuration ui

### DIFF
--- a/ajax/networking/get_netcfg.php
+++ b/ajax/networking/get_netcfg.php
@@ -45,12 +45,14 @@ if (isset($interface)) {
     preg_match('/static\srouters=(.*)/', $matched[0], $static_routers);
     preg_match('/static\sdomain_name_server=(.*)/', $matched[0], $static_dns);
     preg_match('/fallback\sstatic_'.$interface.'/', $matched[0], $fallback);
+    preg_match('/(?:no)?gateway/', $matched[0], $gateway);
     $dhcpdata['Metric'] = $metric[1];
     $dhcpdata['StaticIP'] = strpos($static_ip[1],'/') ?  substr($static_ip[1], 0, strpos($static_ip[1],'/')) : $static_ip[1];
     $dhcpdata['SubnetMask'] = cidr2mask($static_ip[1]);
     $dhcpdata['StaticRouters'] = $static_routers[1];
     $dhcpdata['StaticDNS'] = $static_dns[1];
     $dhcpdata['FallbackEnabled'] = empty($fallback) ? false: true;
+    $dhcpdata['DefaultRoute'] = empty($gateway) || $gateway[0] == "gateway";
 
     echo json_encode($dhcpdata);
 }

--- a/app/js/custom.js
+++ b/app/js/custom.js
@@ -186,6 +186,7 @@ function loadInterfaceDHCPSelect() {
         $('#txtsubnetmask').val(jsonData.SubnetMask);
         $('#txtgateway').val(jsonData.StaticRouters);
         $('#chkfallback')[0].checked = jsonData.FallbackEnabled;
+        $('#default-route').prop('checked', jsonData.DefaultRoute);
         $('#txtrangestart').val(jsonData.RangeStart);
         $('#txtrangeend').val(jsonData.RangeEnd);
         $('#txtrangeleasetime').val(jsonData.leaseTime);

--- a/includes/dhcp.php
+++ b/includes/dhcp.php
@@ -244,6 +244,7 @@ function updateDHCPConfig($iface,$status)
         $cfg[] = 'profile static_'.$iface;
         $cfg[] = 'fallback static_'.$iface;
     }
+    $cfg[] = $_POST['DefaultRoute'] == '1' ? 'gateway' : 'nogateway';
     $dhcp_cfg = file_get_contents(RASPI_DHCPCD_CONFIG);
     if (!preg_match('/^interface\s'.$iface.'$/m', $dhcp_cfg)) {
         $cfg[] = PHP_EOL;

--- a/locale/en_US/LC_MESSAGES/messages.po
+++ b/locale/en_US/LC_MESSAGES/messages.po
@@ -362,6 +362,9 @@ msgstr "Log DHCP requests"
 msgid "Log DNS queries"
 msgstr "Log DNS queries"
 
+msgid "This toggles the <code>gateway</code>/<code>nogateway</code> option for this interface in the DHCPCD configuration."
+msgstr "This toggles the <code>gateway</code>/<code>nogateway</code> option for this interface in the DHCPCD configuration."
+
 #: includes/hostapd.php
 msgid "Basic"
 msgstr "Basic"

--- a/templates/dhcp/general.php
+++ b/templates/dhcp/general.php
@@ -55,6 +55,18 @@
     </div>
   </div>
 
+  <div class="row">
+    <div class="form-group col-md-6">
+        <div class="custom-control custom-switch">
+          <input class="custom-control-input" id="default-route" type="checkbox" name="DefaultRoute" value="1" aria-describedby="default-route-description">
+          <label class="custom-control-label" for="default-route"><?php echo _("Install a default route for this interface") ?></label>
+        </div>
+        <p class="mb-0" id="default-route-description">
+          <small><?php echo _("This toggles the <code>gateway</code>/<code>nogateway</code> option for this interface in the DHCPCD configuration.") ?></small>
+        </p>
+    </div>
+  </div>
+
   <h5 class="mt-1">DHCP options</h5>
   <div class="row">
     <div class="form-group col-md-6">


### PR DESCRIPTION
the problem i'm trying to solve has to do with multiple wlan interfaces and routing.

i have

- `wlan0` (internal raspberry phy)
- `wlan1` (usb ralink phy)

i use wlan1 as the client interface (connecting to the hotel wifi) and wlan0 as the hostapd interface. wlan0 gets assigned a static ip by dhcpcd. wlan1 gets its ip from the upstream dhcp server of the hotel network.

right now the routing table looks like this:

```
# route
Kernel IP routing table
Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
default         192.168.50.1    0.0.0.0         UG    303    0        0 wlan0
default         192.168.100.1   0.0.0.0         UG    304    0        0 wlan1
192.168.50.0    0.0.0.0         255.255.255.0   U     303    0        0 wlan0
192.168.100.0   0.0.0.0         255.255.255.0   U     304    0        0 wlan1
```

and no external connections work because (i think) everything takes the first default route.
everything starts to work when i remove that route:

    ip route del default via 192.168.50.1

so the root problem appears to be the installation of a default route for the hostapd interface wlan0.

dhcpcd.conf
```
# RaspAP default configuration
hostname
clientid
persistent
option rapid_commit
option domain_name_servers, domain_name, domain_search, host_name
option classless_static_routes
option ntp_servers
require dhcp_server_identifier
slaac private
nohook lookup-hostname

# RaspAP wlan0 configuration
interface wlan0
static ip_address=192.168.50.1/24
static routers=192.168.50.1
```

to disable the installation of that default route for wlan0, the interface configuration in `dhcpcd.conf` needs a `nogateway` option.

this pr adds a toggle to accomplish this. we should probably do this automagically based on configuration but this was the quickest way for me to implement right now.

any thoughts?