### PR TITLE
Improved css theming

### DIFF
--- a/app/css/custom.php
+++ b/app/css/custom.php
@@ -164,7 +164,15 @@ i.fa.fa-bars:hover{
 }
 
 .service-status {
-  border-width: 0;
+  display: flex;
+  align-items: center;
+}
+.service-status .icon,
+.service-status .text {
+  display: flex;
+  margin: 0.5rem;
+  font-size: 1rem;
+  padding: .3rem;
 }
 
 .service-status-up {

--- a/app/css/custom.php
+++ b/app/css/custom.php
@@ -165,14 +165,14 @@ i.fa.fa-bars:hover{
 
 .service-status {
   display: flex;
-  align-items: center;
+  align-items: stretch;
+  justify-content: center;
 }
 .service-status .icon,
 .service-status .text {
   display: flex;
-  margin: 0.5rem;
-  font-size: 1rem;
-  padding: .3rem;
+  font-size: 0.8rem;
+  align-items: center;
 }
 
 .service-status-up {

--- a/app/css/custom.php
+++ b/app/css/custom.php
@@ -23,13 +23,34 @@ body {
 
 /* Small devices (portrait phones, up to 576px) */
 @media (max-width: 576px) {
-  .container-fluid, .card-body, .col-md-6 { padding-left: 0.5rem; padding-right: 0.5rem; }
-  .card .card-header { padding: .75rem .5rem; font-size: 1.0rem; }
-  .row { margin-left: 0rem; margin-right: 0rem; }
-  .col-lg-12 { padding-right: 0.25rem; padding-left: 0.25rem; }
-  .form-group.col-md-6 { margin-left: -0.5rem; }
-  .js-wifi-stations { margin-left: -0.5rem; margin-right: -0.5rem; }
-  h4.mt-3 { margin-left: 0.5rem; }
+  .container-fluid,
+  .card-body,
+  .col-md-6 {
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
+  .card .card-header {
+    padding: .75rem .5rem;
+    font-size: 1.0rem;
+  }
+  .row {
+    margin-left: 0rem;
+    margin-right: 0rem;
+  }
+  .col-lg-12 {
+    padding-right: 0.25rem;
+    padding-left: 0.25rem;
+  }
+  .form-group.col-md-6 {
+    margin-left: -0.5rem;
+  }
+  .js-wifi-stations {
+    margin-left: -0.5rem;
+    margin-right: -0.5rem;
+  }
+  h4.mt-3 {
+    margin-left: 0.5rem;
+  }
 }
 
 .sidebar {

--- a/app/css/custom.php
+++ b/app/css/custom.php
@@ -1,5 +1,12 @@
 <?php
 header("Content-Type: text/css; charset=utf-8");
+$filemtime = filemtime(__FILE__);
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s T', $filemtime));
+if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) && strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE']) >= $filemtime)
+{
+    header('HTTP/1.0 304 Not Modified');
+    exit;
+}
 require_once '../../includes/functions.php';
 $color = getColorOpt();
 ?>

--- a/app/css/custom.php
+++ b/app/css/custom.php
@@ -1,5 +1,5 @@
-<?php header("Content-Type: text/css; charset=utf-8"); ?>
 <?php
+header("Content-Type: text/css; charset=utf-8");
 require_once '../../includes/functions.php';
 $color = getColorOpt();
 ?>

--- a/app/css/custom.php
+++ b/app/css/custom.php
@@ -176,15 +176,15 @@ i.fa.fa-bars:hover{
 }
 
 .service-status-up {
-  color: #a1ec38;
+  color: #a1ec38 !important;
 }
 
 .service-status-warn {
-  color: #f6f044;
+  color: #f6f044 !important;
 }
 
 .service-status-down {
-  color: #f80107;
+  color: #f80107 !important;
   animation: flash 1s linear infinite;
 }
 @keyframes flash {

--- a/app/css/custom.php
+++ b/app/css/custom.php
@@ -16,10 +16,6 @@ body {
   color: #212529;
 }
 
-.page-header {
-  margin: 20px 0 20px;
-}
-
 .navbar-logo {
   margin-top: 0.5em;
   margin-left: 0.5em;
@@ -90,7 +86,7 @@ a.nav-link.active {
 }
 
 .sidebar .nav-item .nav-link {
-  padding: 0.6rem 0.6rem 0.6rem 1.0rem;
+  padding: 0.6rem;
 }
 
 .alert-success {
@@ -160,7 +156,7 @@ i.fa.fa-bars:hover{
     opacity: 0;
   }
 }
- 
+
 .logoutput {
   width:100%;
   height: 20rem;
@@ -196,7 +192,8 @@ pre.unstyled {
 
 .sidebar.toggled .nav-item .nav-link span {
   display: none;
-} .sidebar .nav-item .nav-link i,
+}
+.sidebar .nav-item .nav-link i,
 .sidebar .nav-item .nav-link span {
     font-size: 1.0rem;
 }
@@ -235,16 +232,3 @@ canvas#divDBChartBandwidthhourly {
   opacity: 0;
   color: #90ee90;
 }
-
-.check-progress {
-  color: #999;
-}
-
-.fa-check {
-  color: #90ee90;
-}
-
-.fa-times {
-  color: #ff4500;
-}
-

--- a/app/css/hackernews.css
+++ b/app/css/hackernews.css
@@ -8,7 +8,6 @@ License: GNU General Public License v3.0
 
 html * {
   font-family: Verdana, Geneva, sans-serif;
-  font-size: 0.9rem;
   color: #828282;
 }
 
@@ -16,17 +15,11 @@ a:focus, a:hover {
   color: #666;
 }
 
-h2 {
-  font-size: 2rem !important;
-}
-
 h4 {
-  font-size: 1.3rem;
   color: #212529;
 }
 
 h5.card-title {
-  font-size: 1.2rem;
   color: #212529;
 }
 
@@ -39,24 +32,19 @@ h5.card-title {
   border-color: #ff6600;
   background-color: #ff6600;
   color: #000;
-  font-size: 1.0rem;
-  font-weight: bold;
   border-radius: unset;
 }
 
 .card-header .col {
   color: #212529;
-  font-size: 1.0rem;
 }
 
 .card-header [class^="fa"], .modal-header [class^="fa"] {
   color: #fff;
-  font-size: 1.0rem;
 }
 
 .modal-title {
   color: #000;
-  font-size: 1.0rem;
 }
 
 .modal-content {
@@ -128,11 +116,6 @@ ul.nav-tabs, .nav-tabs .nav-link {
   text-align: center;
   padding: .6rem 1rem;
   width: 6.5rem;
-}
-
-.sidebar .nav-item .nav-link i,
-.sidebar .nav-item .nav-link span {
-  font-size: 0.9rem;
 }
 
 .toggle-off.btn {

--- a/app/css/hackernews.css
+++ b/app/css/hackernews.css
@@ -12,10 +12,6 @@ html * {
   color: #828282;
 }
 
-body {
-  color: #212529;
-}
-
 a:focus, a:hover {
   color: #666;
 }
@@ -68,10 +64,6 @@ h5.card-title {
 }
 
 .sidebar-brand-text {
-  text-transform: none;
-  color: #212529;
-  font-size: 2.0rem;
-  font-weight: 500;
   font-family: Verdana, Geneva, sans-serif;
 }
 
@@ -81,39 +73,14 @@ ul.nav-tabs, .nav-tabs .nav-link {
   border-bottom: 1px solid #dddfeb;
 }
 
-.sidebar .nav-item .nav-link {
-  padding: 0.6rem;
-}
-
 .sidebar-light .nav-item.active .nav-link {
   font-weight: 300;
-}
-
-.page-header {
-  font-size: 26pt;
-  margin: 10px 0 20px;
-}
-
-.navbar-logo {
-  margin-top: 0.5em;
-  margin-left: 0.5em;
 }
 
 #wrapper,#page-wrapper,
 #wrapper #content-wrapper,
 .nav>li>a,.nav {
   background-color: #fff;
-}
-
-/* Small devices (portrait phones, up to 576px) */
-@media (max-width: 576px) {
-  .container-fluid, .card-body, .col-md-6 { padding-left: 0.5rem; padding-right: 0.5rem; }
-  .card .card-header { padding: .75rem .5rem; font-size: 1.0rem; }
-  .row { margin-left: 0rem; margin-right: 0rem; }
-  .col-lg-12 { padding-right: 0.25rem; padding-left: 0.25rem; }
-  .form-group.col-md-6 { margin-left: -0.5rem; }
-  .js-wifi-stations { margin-left: -0.5rem; margin-right: -0.5rem; }
-  h4.mt-3 { margin-left: 0.5rem; }
 }
 
 .card-body {
@@ -146,81 +113,11 @@ ul.nav-tabs, .nav-tabs .nav-link {
   color: #eee;
 }
 
-.info-item {
-  text-transform: uppercase;
-  font-size: 0.7em;
-  color: #858796;
-}
-
-.info-value {
-  font-size: 0.7rem;
-  margin-left: 0.7rem;
-}
-
-.info-item-xs {
-  font-size: 0.7rem;
-  margin-left: 0.3rem;
-}
-
-.info-item-wifi {
-  width: 6rem;
-  float: left;
-}
-
 .logoutput {
   width: 100%;
-  height: 20rem;
+  height: 300px;
   border: 1px solid #d1d3e2;
   border-radius: .35rem;
-}
-
-.service-status {
-  border-width: 0;
-}
-
-.service-status-up {
-  color: #a1ec38!important;
-}
-
-.service-status-warn {
-  color: #f6f044!important;
-}
-
-.service-status-down {
-  color: #f80107!important;
-  animation: flash 1s linear infinite;
-}
-@keyframes flash {
-  50% {
-    opacity: 0;
-  }
-}
-
-.logoutput {
-  width:100%;
-  height:300px;
-}
-
-pre.unstyled {
-  border-width: 0;
-  background-color: transparent;
-  padding: 0;
-}
-
-.dhcp-static-leases {
-  margin-top: 1em;
-  margin-bottom: 1em;
-}
-
-.dhcp-static-lease-row {
-  margin-top: 0.5em;
-  margin-bottom: 0.5em;
-}
-
-.loading-spinner {
-  background: url("../../app/img/loading-spinner.gif") no-repeat scroll center center transparent;
-  min-height: 150px;
-  width: 100%;
 }
 
 .js-reload-wifi-stations {
@@ -233,56 +130,15 @@ pre.unstyled {
   width: 6.5rem;
 }
 
-.sidebar.toggled .nav-item .nav-link span {
-  display: none;
-} .sidebar .nav-item .nav-link i,
+.sidebar .nav-item .nav-link i,
 .sidebar .nav-item .nav-link span {
   font-size: 0.9rem;
 }
 
-.btn-warning:hover {
-    color: #000;
-}
-
 .toggle-off.btn {
   padding-left: 0.9rem;
-  font-size: 0.9rem!important;
-}
-
-.toggle-on.btn {
-  font-size: 0.9rem!important;
-}
-
-canvas#divDBChartBandwidthhourly {
-  height: 350px!important;
-}
-
-.chart-container {
-  height: 150px;
-  width: 200px;
-}
-.table {
-  margin-bottom: 0rem;
-}
-
-.check-hidden {
-  visibility: hidden;
 }
 
 .check-updated {
-  opacity: 0;
   color: #1cc88a;
 }
-
-.check-progress {
-  color: #999;
-}
-
-.fa-check {
-  color: #90ee90;
-}
-
-.fa-times {
-  color: #ff4500;
-}
-

--- a/app/css/lightsout.css
+++ b/app/css/lightsout.css
@@ -100,9 +100,6 @@ a:focus, a:hover {
   color: #202020;
 }
 
-.card-header [class^="fa"] {
-  color: #afafaf;
-}
 
 .col {
   color: #afafaf;

--- a/app/css/lightsout.css
+++ b/app/css/lightsout.css
@@ -8,20 +8,7 @@ License: GNU General Public License v3.0
 
 html * {
   font-family: Helvetica,Arial,sans-serif;
-  font-size: 1.0rem;
   color: #afafaf;
-}
-
-h2 {
-  font-size: 2rem !important;
-}
-
-h4 {
-  font-size: 1.3rem;
-}
-
-h5.card-title {
-  font-size: 1.2rem;
 }
 
 .navbar-logo {
@@ -46,10 +33,6 @@ h5.card-title {
 
 .nav-tabs {
   border-bottom: 1px solid #404040;
-}
-.nav-tabs .nav-link.active,
-.nav-tabs .nav-link {
-  font-size: 1.0rem;
 }
 
 .nav-tabs .nav-link:hover {
@@ -107,8 +90,6 @@ a:focus, a:hover {
   color: #afafaf;
   border-top-right-radius: 3px;
   border-top-left-radius: 3px;
-  font-size: 1.0rem;
-  font-weight: 400;
 }
 
 .modal-body {
@@ -121,7 +102,6 @@ a:focus, a:hover {
 
 .card-header [class^="fa"] {
   color: #afafaf;
-  font-size: 1.0rem;
 }
 
 .col {
@@ -214,10 +194,6 @@ hr {
   padding-top: 0.5rem;
 }
 
-.sidebar .nav-item .nav-link span {
-  font-size: 1.0rem;
-}
-
 .topbar .topbar-divider {
   border-right: 1px solid #404040;
 }
@@ -276,8 +252,6 @@ span.label.label-warning {
 }
 
 .close {
-  font-size: 1.2em;
-  font-weight: 400;
   text-shadow: none;
   color: #d2d2d2;
 }
@@ -331,16 +305,7 @@ tspan, rect {
 }
 
 span.text.service-status {
-  font-size: 0.75rem;
   margin-top: 0.2rem;
-}
-
-.text-muted {
-  font-size: 0.8rem;
-}
-
-.fas.fa-circle {
-  font-size: 0.5rem;
 }
 
 pre {

--- a/app/css/lightsout.css
+++ b/app/css/lightsout.css
@@ -301,10 +301,6 @@ tspan, rect {
   fill: #d2d2d2;
 }
 
-span.text.service-status {
-  margin-top: 0.2rem;
-}
-
 pre {
   background-color: #202020;
   border: #202020;

--- a/app/css/lightsout.css
+++ b/app/css/lightsout.css
@@ -24,14 +24,7 @@ h5.card-title {
   font-size: 1.2rem;
 }
 
-.page-header {
-  padding: 0 20px;
-  border-left: .01rem solid #d2d2d2;
-}
-
 .navbar-logo {
-  margin-top: 0.5em;
-  margin-left: 0.5em;
   filter: brightness(70%);
 }
 
@@ -45,17 +38,6 @@ h5.card-title {
 
 #wrapper #content-wrapper #content {
   background-color: #202020;
-}
-
-/* Small devices (portait phones, up to 576px) */
-@media (max-width: 576px) {
-  .container-fluid, .card-body, .col-md-6 { padding-left: 0.5rem; padding-right: 0.5rem; }
-  .card .card-header { padding: .75rem .5rem; font-size: 1.0rem; }
-  .row { margin-left: 0rem; margin-right: 0rem; }
-  .col-lg-12 { padding-right: 0.25rem; padding-left: 0.25rem; }
-  .form-group.col-md-6 { margin-left: -0.5rem; }
-  .js-wifi-stations { margin-left: -0.5rem; margin-right: -0.5rem; }
-  h4.mt-3 { margin-left: 0.5rem; }
 }
 
 .topbar {
@@ -152,21 +134,12 @@ a:focus, a:hover {
   background-color: #141414;
 }
 
-hr { 
+hr {
   border-top: .01rem solid #d2d2d2;
 }
 
-.page-header {
-  font-size: 24pt;
-  margin: 10px 0 20px;
-  border-bottom: .01rem solid #d2d2d2;
-}
-
 .sidebar-brand-text {
-  text-transform: none;
   color: #ac1b3d;
-  font-size: 2.0rem;
-  font-weight: 500;
   font-family: inherit;
 }
 
@@ -249,26 +222,9 @@ hr {
   border-right: 1px solid #404040;
 }
 
-.info-item {
-  text-transform: uppercase;
-  font-size: 0.7em;
-  color: #858796;
-}
-
-.info-value {
-  font-size: 0.7rem;
-  margin-left: 0.7rem;
-}
-
 .info-item-xs {
-  font-size: 0.7rem;
   line-height: 1.5em;
   margin-left: 0.5rem;
-}
-
-.info-item-wifi {
-  width: 6rem;
-  float: left;
 }
 
 .label-warning {
@@ -341,10 +297,10 @@ span.label.label-warning {
   opacity: 0.5;
 }
 
-.form-control::-webkit-input-placeholder { color: #d2d2d2; } 
-.form-control:-moz-placeholder { color: #d2d2d2; }  
-.form-control::-moz-placeholder { color: #d2d2d2; }  
-.form-control:-ms-input-placeholder { color: #d2d2d2; }  
+.form-control::-webkit-input-placeholder { color: #d2d2d2; }
+.form-control:-moz-placeholder { color: #d2d2d2; }
+.form-control::-moz-placeholder { color: #d2d2d2; }
+.form-control:-ms-input-placeholder { color: #d2d2d2; }
 .form-control::-ms-input-placeholder { color: #d2d2d2; }
 
 input[type="text"]{
@@ -365,7 +321,6 @@ color: #d2d2d2 !important
 }
 
 .logoutput {
-  width: 100%;
   height: 300px;
   background-color: #202020;
   border-color: #404040;
@@ -388,89 +343,16 @@ span.text.service-status {
   font-size: 0.5rem;
 }
 
-.service-status-up {
-  color: #a1ec38 !important;
-}
-
-.service-status-warn {
-  color: #f6f044 !important;
-}
-
-.service-status-down {
-  color: #f80107 !important;
-  animation: flash 1s linear infinite;
-}
-@keyframes flash {
-  50% {
-    opacity: 0;
-  }
-}
-
 pre {
   background-color: #202020;
   border: #202020;
-}
-
-.dhcp-static-leases {
-  margin-top: 1em;
-  margin-bottom: 1em;
-}
-
-.dhcp-static-lease-row {
-  margin-top: 0.5em;
-  margin-bottom: 0.5em;
-}
-
-.loading-spinner {
-  background: url("../../app/img/loading-spinner.gif") no-repeat scroll center center transparent;
-  min-height: 150px;
-  width: 100%;
-}
-
-.toggle-off.btn {
-  padding-left: 1.2rem;
-  font-size: 0.9rem!important;
-}
-
-.toggle-on.btn {
-  font-size: 0.9rem!important;
-}
-
-canvas#divDBChartBandwidthhourly {
-  height: 350px!important;
-}
-
-.chart-container {
-  height: 150px;
-  width: 200px;
-}
-
-.table {
-  margin-bottom: 0rem;
 }
 
 .figure, .authors {
   filter: brightness(70%) !important;
 }
 
-.check-hidden {
-  visibility: hidden;
-}
-
 .check-updated {
-  opacity: 0;
   color: #1cc88a;
-}
-
-.check-progress {
-  color: #999;
-}
-
-.fa-check {
-  color: #90ee90;
-}
-
-.fa-times {
-  color: #ff4500;
 }
 

--- a/app/js/custom.js
+++ b/app/js/custom.js
@@ -353,7 +353,7 @@ $(document).on("keyup", ".js-validate-psk", function(e) {
 
 $(document).on("change", "#theme-select", function(e) {
   $('link[data-type=theme]').prop('disabled', true)
-  $('link[href$='+e.target.value+']').prop('disabled', false)
+  $('link[href$="'+e.target.value+'"]').prop('disabled', false)
 })
 
 function setCookie(cname, cvalue, exdays) {

--- a/app/js/custom.js
+++ b/app/js/custom.js
@@ -354,6 +354,7 @@ $(document).on("keyup", ".js-validate-psk", function(e) {
 $(document).on("change", "#theme-select", function(e) {
   $('link[data-type=theme]').prop('disabled', true)
   $('link[href$="'+e.target.value+'"]').prop('disabled', false)
+  setCookie('theme', e.target.value, 90)
 })
 
 function setCookie(cname, cvalue, exdays) {

--- a/app/js/custom.js
+++ b/app/js/custom.js
@@ -351,18 +351,10 @@ $(document).on("keyup", ".js-validate-psk", function(e) {
     }
 });
 
-$(function() {
-    $('#theme-select').change(function() {
-        var theme = themes[$( "#theme-select" ).val() ]; 
-        set_theme(theme);
-   });
-});
-
-function set_theme(theme) {
-    $('link[title="main"]').attr('href', 'app/css/' + theme);
-    // persist selected theme in cookie 
-    setCookie('theme',theme,90);
-}
+$(document).on("change", "#theme-select", function(e) {
+  $('link[data-type=theme]').prop('disabled', true)
+  $('link[href$='+e.target.value+']').prop('disabled', false)
+})
 
 function setCookie(cname, cvalue, exdays) {
     var d = new Date();

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -604,12 +604,7 @@ function formatDateAgo($datetime, $full = false)
 
 function getThemeOpt()
 {
-    if (!isset($_COOKIE['theme'])) {
-        $theme = "custom.php";
-    } else {
-        $theme = $_COOKIE['theme'];
-    }
-    return 'app/css/'.htmlspecialchars($theme, ENT_QUOTES);
+    return htmlspecialchars($theme, ENT_QUOTES);
 }
 
 function getColorOpt()

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -636,3 +636,10 @@ function validate_host($host) {
   return preg_match('/^([a-z\d](-*[a-z\d])*)(\.([a-z\d](-*[a-z\d])*))*$/i', $host);
 }
 
+function availableThemes() {
+  return [
+    ""               => "RaspAP (default)",
+    "hackernews.css" => "HackerNews",
+    "lightsout.css"  => "Lights Out"
+  ];
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -328,10 +328,10 @@ function SelectorOptions($name, $options, $selected = null, $id = null, $event =
     foreach ($options as $opt => $label) {
         $select = '';
         $key = isAssoc($options) ? $opt : $label;
-        if ($key == $selected) {
+        if ($key === $selected) {
             $select = ' selected="selected"';
         }
-        if ($key == $disabled) {
+        if ($key === $disabled) {
             $disabled = ' disabled';
         }
         echo '<option value="'.htmlspecialchars($key, ENT_QUOTES).'"'.$select.$disabled.'>'.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -604,7 +604,7 @@ function formatDateAgo($datetime, $full = false)
 
 function getThemeOpt()
 {
-    return htmlspecialchars($theme, ENT_QUOTES);
+    return htmlspecialchars($_COOKIE['theme'], ENT_QUOTES);
 }
 
 function getColorOpt()

--- a/includes/themes.php
+++ b/includes/themes.php
@@ -10,7 +10,7 @@ function DisplayThemeConfig(&$extraFooterScripts)
 {
     $themes = availableThemes();
     $validTheme = in_array($_COOKIE['theme'], array_keys($themes));
-    $selectedTheme = $validTheme ?? $_COOKIE['theme'];
+    $selectedTheme = $validTheme ? $_COOKIE['theme'] : null;
 
     echo renderTemplate("themes", compact("themes", "selectedTheme"));
 

--- a/includes/themes.php
+++ b/includes/themes.php
@@ -1,21 +1,16 @@
 <?php
+
+require_once 'includes/functions.php';
+
 /**
  *
  *
  */
 function DisplayThemeConfig(&$extraFooterScripts)
 {
-    $themes = [
-        "default"    => "RaspAP (default)",
-        "hackernews" => "HackerNews",
-        "lightsout"  => "Lights Out"
-    ];
-    $themeFiles = [
-        "default"    => "custom.php",
-        "hackernews" => "hackernews.css",
-        "lightsout"  => "lightsout.css"
-    ];
-    $selectedTheme = array_search($_COOKIE['theme'], $themeFiles);
+    $themes = availableThemes();
+    $validTheme = in_array($_COOKIE['theme'], array_keys($themes));
+    $selectedTheme = $validTheme ?? $_COOKIE['theme'];
 
     echo renderTemplate("themes", compact("themes", "selectedTheme"));
 

--- a/index.php
+++ b/index.php
@@ -84,9 +84,9 @@ $bridgedEnabled = getBridgedState();
 
     <!-- Custom CSS -->
     <link href="app/css/custom.php" title="main" rel="stylesheet">
-    <?php if (!empty($theme)): ?>
-    <link href="app/css/<?php echo $theme; ?>" title="<?php echo $theme; ?>" rel="stylesheet">
-    <?php endif ?>
+    <?php foreach (array_slice(availableThemes(), 1) as $file => $name): ?>
+    <link href="app/css/<?php echo $file ?>" title="<?php echo $name ?>" data-type="theme" rel="stylesheet" <?php echo $file != $theme ? "disabled" : "" ?>>
+    <?php endforeach ?>
 
     <link rel="shortcut icon" type="image/png" href="app/icons/favicon.png?ver=2.0">
     <link rel="apple-touch-icon" sizes="180x180" href="app/icons/apple-touch-icon.png">

--- a/index.php
+++ b/index.php
@@ -83,7 +83,7 @@ $bridgedEnabled = getBridgedState();
     <link href="dist/fontawesome-free/css/all.min.css" rel="stylesheet" type="text/css">
 
     <!-- Custom CSS -->
-    <link href="app/css/cutom.php" title="main" rel="stylesheet">
+    <link href="app/css/custom.php" title="main" rel="stylesheet">
     <?php if (!empty($theme)): ?>
     <link href="app/css/<?php echo $theme; ?>" title="<?php echo $theme; ?>" rel="stylesheet">
     <?php endif ?>

--- a/index.php
+++ b/index.php
@@ -83,7 +83,10 @@ $bridgedEnabled = getBridgedState();
     <link href="dist/fontawesome-free/css/all.min.css" rel="stylesheet" type="text/css">
 
     <!-- Custom CSS -->
-    <link href="<?php echo $theme_url; ?>" title="main" rel="stylesheet">
+    <link href="app/css/cutom.php" title="main" rel="stylesheet">
+    <?php if (!empty($theme)): ?>
+    <link href="app/css/<?php echo $theme; ?>" title="<?php echo $theme; ?>" rel="stylesheet">
+    <?php endif ?>
 
     <link rel="shortcut icon" type="image/png" href="app/icons/favicon.png?ver=2.0">
     <link rel="apple-touch-icon" sizes="180x180" href="app/icons/apple-touch-icon.png">

--- a/index.php
+++ b/index.php
@@ -51,7 +51,7 @@ $config = getConfig();
 $output = $return = 0;
 $page = $_SERVER['PATH_INFO'];
 
-$theme_url = getThemeOpt();
+$theme = getThemeOpt();
 $toggleState = getSidebarState();
 $bridgedEnabled = getBridgedState();
 

--- a/index.php
+++ b/index.php
@@ -85,8 +85,16 @@ $bridgedEnabled = getBridgedState();
     <!-- Custom CSS -->
     <link href="app/css/custom.php" title="main" rel="stylesheet">
     <?php foreach (array_slice(availableThemes(), 1) as $file => $name): ?>
-    <link href="app/css/<?php echo $file ?>" title="<?php echo $name ?>" data-type="theme" rel="stylesheet" <?php echo $file != $theme ? "disabled" : "" ?>>
+    <link href="app/css/<?php echo $file ?>" title="<?php echo $name ?>" data-type="theme" rel="stylesheet" disabled>
     <?php endforeach ?>
+    <script type="text/javascript">
+      document.addEventListener("DOMContentLoaded", function() {
+        var cookies = "; " + document.cookie
+        var value = cookies.split("; theme=").pop().split(";").shift()
+        var stylesheet = document.querySelector('link[href$="'+value+'"]')
+        if (stylesheet) stylesheet.removeAttribute('disabled')
+      }, false)
+    </script>
 
     <link rel="shortcut icon" type="image/png" href="app/icons/favicon.png?ver=2.0">
     <link rel="apple-touch-icon" sizes="180x180" href="app/icons/apple-touch-icon.png">


### PR DESCRIPTION
1. reduce code duplication in css files
2. use custom.php css as base
3. load theme css after custom.php
4. simpler theme switching logic

observation: i would like to get rid of that disabled-attribute-toggling on `DOMContentLoaded` but for some weird reason the browser would not apply the css if leave out the disabled-attribute in the php logic.