### PR TITLE
interpret hex sequences in ssid station names

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -641,3 +641,10 @@ function validate_host($host) {
   return preg_match('/^([a-z\d](-*[a-z\d])*)(\.([a-z\d](-*[a-z\d])*))*$/i', $host);
 }
 
+function evalHexSequence($string) {
+    $evaluator = function ($input) {
+	return hex2bin($input[1]);
+    };
+    return preg_replace_callback('/\\\x(..)/', $evaluator, $string);
+}
+

--- a/includes/wifi_functions.php
+++ b/includes/wifi_functions.php
@@ -75,6 +75,7 @@ function nearbyWifiStations(&$networks, $cached = true)
         }
 
         $ssid = trim($arrNetwork[4]);
+        $ssid = evalHexSequence($ssid);
         // filter SSID string: anything invisible in 7bit ASCII or quotes -> ignore network
         if (preg_match('[\x00-\x1f\x7f-\xff\'\`\´\"]', $ssid)) {
             continue;

--- a/includes/wifi_functions.php
+++ b/includes/wifi_functions.php
@@ -69,13 +69,15 @@ function nearbyWifiStations(&$networks, $cached = true)
 
     foreach (explode("\n", $scan_results) as $network) {
         $arrNetwork = preg_split("/[\t]+/", $network);  // split result into array
-        if (!array_key_exists(4, $arrNetwork) ||
-            trim($arrNetwork[4]) == $ap_ssid) {
-            continue;
-        }
 
         $ssid = trim($arrNetwork[4]);
         $ssid = evalHexSequence($ssid);
+
+        // exclude raspap ssid
+        if (empty($ssid) || $ssid == $ap_ssid) {
+            continue;
+        }
+
         // filter SSID string: anything invisible in 7bit ASCII or quotes -> ignore network
         if (preg_match('[\x00-\x1f\x7f-\xff\'\`\´\"]', $ssid)) {
             continue;


### PR DESCRIPTION
resolves #917

before:
<img width="264" alt="Bildschirmfoto 2021-05-30 um 17 46 16" src="https://user-images.githubusercontent.com/201135/120119718-ad6c0400-c16f-11eb-933e-1d9d6e0b88a4.png">

after:
<img width="239" alt="Bildschirmfoto 2021-05-30 um 17 46 48" src="https://user-images.githubusercontent.com/201135/120119721-b3fa7b80-c16f-11eb-8359-7a087ec66dbd.png">
