### PR TITLE
Changed "language" from "linguaggio" to "lingua"

### DIFF
--- a/locale/it_IT/LC_MESSAGES/messages.po
+++ b/locale/it_IT/LC_MESSAGES/messages.po
@@ -539,7 +539,7 @@ msgid "System Information"
 msgstr "Informazioni di sistema"
 
 msgid "Language"
-msgstr "Linguaggio"
+msgstr "Lingua"
 
 msgid "Language settings"
 msgstr "Impostazioni lingua"


### PR DESCRIPTION
“Lingua” turns out to be more appropriate than “linguaggio” for language selection, as also used for the following entries.