### PR TITLE
Issue #1016 dhcp wrong subnet

### DIFF
--- a/includes/dhcp.php
+++ b/includes/dhcp.php
@@ -182,7 +182,7 @@ function updateDnsmasqConfig($iface,$status)
     $config = '# RaspAP '.$iface.' configuration'.PHP_EOL;
     $config .= 'interface='.$iface.PHP_EOL.
         'dhcp-range='.$_POST['RangeStart'].','.$_POST['RangeEnd'].
-        ',255.255.255.0,';
+        ','.$_POST['SubnetMask'].',';
     if ($_POST['RangeLeaseTimeUnits'] !== 'infinite') {
         $config .= $_POST['RangeLeaseTime'];
     }

--- a/includes/dhcp.php
+++ b/includes/dhcp.php
@@ -180,9 +180,7 @@ function compareIPs($ip1, $ip2)
 function updateDnsmasqConfig($iface,$status)
 {
     $config = '# RaspAP '.$iface.' configuration'.PHP_EOL;
-    $config .= 'interface='.$iface.PHP_EOL.
-        'dhcp-range='.$_POST['RangeStart'].','.$_POST['RangeEnd'].
-        ','.$_POST['SubnetMask'].',';
+    $config .= 'interface='.$iface.PHP_EOL.'dhcp-range='.$_POST['RangeStart'].','.$_POST['RangeEnd'].','.$_POST['SubnetMask'].',';
     if ($_POST['RangeLeaseTimeUnits'] !== 'infinite') {
         $config .= $_POST['RangeLeaseTime'];
     }


### PR DESCRIPTION
FIx for issue #1016 


The subnet mask was hard coded in /includes/dhcp.php line 183

concatenated the $POST data instead.