### PR TITLE
removing stale iptables rule in installer

### DIFF
--- a/installers/common.sh
+++ b/installers/common.sh
@@ -554,7 +554,6 @@ function _configure_networking() {
     echo "Checking iptables rules"
     rules=(
     "-A POSTROUTING -j MASQUERADE"
-    "-A POSTROUTING -s 192.168.50.0/24 ! -d 192.168.50.0/24 -j MASQUERADE"
     )
     for rule in "${rules[@]}"; do
         if grep -- "$rule" $rulesv4 > /dev/null; then


### PR DESCRIPTION
Removing the unused POSTROUTING rule from the installer. The uninstaller retains the delete rule, which will fail gracefully for newer installations and correctly remove the rule on older/current installations.