### PR TITLE
Fix: function usedMemory

### DIFF
--- a/app/lib/system.php
+++ b/app/lib/system.php
@@ -42,7 +42,7 @@ class Sysinfo
 
     public function usedMemory()
     {
-        $used = shell_exec("free -m | awk '/Mem:/ { total=$2 ; used=$3 } END { print used/total*100}'");
+        $used = shell_exec("free -m | awk 'NR==2{ total=$2 ; used=$3 } END { print used/total*100}'");
         return floor($used);
     }
 


### PR DESCRIPTION
command `free -m` will return text without `Mem:` if locale was setting to some language like `zh_CN`
```sh
               total        used        free      shared  buff/cache   available
内存：        922         213         495           3         213         667
交换：         99           0          99
```
and function `usedMemory()` may return `nan`, so I use line 2(`NR==2`)  to replace pattern `/Mem:/`.