### PR TITLE
Wrong assumption of default behaviour

### DIFF
--- a/installers/common.sh
+++ b/installers/common.sh
@@ -675,7 +675,7 @@ function _install_complete() {
         # Prompt to reboot if wired ethernet (eth0) is connected.
         # With default_configuration this will create an active AP on restart.
         if ip a | grep -q ': eth0:.*state UP'; then
-            echo -n "The system needs to be rebooted as a final step. Reboot now? [y/N]: "
+            echo -n "The system needs to be rebooted as a final step. Reboot now? [Y/n]: "
             read answer < /dev/tty
             if [ "$answer" != "${answer#[Nn]}" ]; then
                 echo "Installation reboot aborted."


### PR DESCRIPTION
As the default behaviour is the reboot, the "yes" option should (like before) stand out. Alternatively one can make default that the device does not reboot. Solving [this issue](https://github.com/RaspAP/raspap-webgui/issues/1136#issue-1161837185).