### PR TITLE
Input sanitization for wpa client, Fix for #1325

### DIFF
--- a/includes/configure_client.php
+++ b/includes/configure_client.php
@@ -19,8 +19,10 @@ function DisplayWPAConfig()
         $result = 0;
         $iface = escapeshellarg($_SESSION['wifi_client_interface']);
         $netid = escapeshellarg(strval($_POST['connect']));
-        exec('sudo wpa_cli -i ' . $iface . ' select_network ' . $netid);
-        $status->addMessage('New network selected', 'success');
+        if (is_numeric($netid)) {
+            exec('sudo wpa_cli -i ' . $iface . ' select_network ' . $netid);
+            $status->addMessage('New network selected', 'success');
+        }
     } elseif (isset($_POST['wpa_reinit'])) {
         $status->addMessage('Reinitializing wpa_supplicant', 'info', false);
         $force_remove = true;

--- a/includes/configure_client.php
+++ b/includes/configure_client.php
@@ -17,7 +17,9 @@ function DisplayWPAConfig()
 
     if (isset($_POST['connect'])) {
         $result = 0;
-        exec('sudo wpa_cli -i ' . $_SESSION['wifi_client_interface'] . ' select_network '.strval($_POST['connect']));
+        $iface = escapeshellarg($_SESSION['wifi_client_interface']);
+        $netid = escapeshellarg(strval($_POST['connect']));
+        exec('sudo wpa_cli -i ' . $iface . ' select_network ' . $netid);
         $status->addMessage('New network selected', 'success');
     } elseif (isset($_POST['wpa_reinit'])) {
         $status->addMessage('Reinitializing wpa_supplicant', 'info', false);


### PR DESCRIPTION
I'm not familiar enough with `wpa_supplicant`, but if the intended network ID is always numerical, I would recommend also adding a check for `isnumeric()` of the `$_POST` parameter for a little bit of extra constraint.