### PR TITLE
Adding support for flagging nohook/hoook wpa_supplicant

### DIFF
--- a/ajax/networking/get_netcfg.php
+++ b/ajax/networking/get_netcfg.php
@@ -39,13 +39,14 @@ if (isset($interface)) {
 
     // fetch dhcpcd.conf settings for interface
     $conf = file_get_contents(RASPI_DHCPCD_CONFIG);
-    preg_match('/^#\sRaspAP\s'.$interface.'\s.*?(?=\s*+$)/ms', $conf, $matched);
+    preg_match('/^#\sRaspAP\s'.$interface.'\s.*?(?=\s*+($|#\sRaspAP))/ms', $conf, $matched);
     preg_match('/metric\s(\d*)/', $matched[0], $metric);
     preg_match('/static\sip_address=(.*)/', $matched[0], $static_ip);
     preg_match('/static\srouters=(.*)/', $matched[0], $static_routers);
     preg_match('/static\sdomain_name_server=(.*)/', $matched[0], $static_dns);
     preg_match('/fallback\sstatic_'.$interface.'/', $matched[0], $fallback);
     preg_match('/(?:no)?gateway/', $matched[0], $gateway);
+    preg_match('/(?:no)?hook wpa_supplicant/', $matched[0], $hook_wpa_supplicant);
     $dhcpdata['Metric'] = $metric[1];
     $dhcpdata['StaticIP'] = strpos($static_ip[1],'/') ?  substr($static_ip[1], 0, strpos($static_ip[1],'/')) : $static_ip[1];
     $dhcpdata['SubnetMask'] = cidr2mask($static_ip[1]);
@@ -53,6 +54,7 @@ if (isset($interface)) {
     $dhcpdata['StaticDNS'] = $static_dns[1];
     $dhcpdata['FallbackEnabled'] = empty($fallback) ? false: true;
     $dhcpdata['DefaultRoute'] = $gateway[0] == "gateway";
+    $dhcpdata['HookWPASupplicant'] = $hook_wpa_supplicant[0] !== "nohook wpa_supplicant";
 
     echo json_encode($dhcpdata);
 }

--- a/app/js/custom.js
+++ b/app/js/custom.js
@@ -216,6 +216,12 @@ function loadInterfaceDHCPSelect() {
         $('#txtgateway').val(jsonData.StaticRouters);
         $('#chkfallback')[0].checked = jsonData.FallbackEnabled;
         $('#default-route').prop('checked', jsonData.DefaultRoute);
+        if (strInterface.startsWith("wl")) {
+            $('#hook-wpa-supplicant').parent().parent().parent().show()
+            $('#hook-wpa-supplicant').prop('checked', jsonData.HookWPASupplicant);
+        } else {
+            $('#hook-wpa-supplicant').parent().parent().parent().hide()
+        }
         $('#txtrangestart').val(jsonData.RangeStart);
         $('#txtrangeend').val(jsonData.RangeEnd);
         $('#txtrangeleasetime').val(jsonData.leaseTime);

--- a/config/dhcpcd.conf
+++ b/config/dhcpcd.conf
@@ -15,4 +15,4 @@ interface wlan0
 static ip_address=10.3.141.1/24
 static routers=10.3.141.1
 static domain_name_server=9.9.9.9 1.1.1.1
-
+hook wpa_supplicant

--- a/includes/dhcp.php
+++ b/includes/dhcp.php
@@ -253,11 +253,11 @@ function updateDHCPConfig($iface,$status)
 {
     $cfg[] = '# RaspAP '.$iface.' configuration';
     $cfg[] = 'interface '.$iface;
-    if (isset($_POST['StaticIP'])) {
+    if (isset($_POST['StaticIP']) && $_POST['StaticIP'] !== '') {
         $mask = ($_POST['SubnetMask'] !== '' && $_POST['SubnetMask'] !== '0.0.0.0') ? '/'.mask2cidr($_POST['SubnetMask']) : null;
         $cfg[] = 'static ip_address='.$_POST['StaticIP'].$mask;
     }
-    if (isset($_POST['DefaultGateway'])) {
+    if (isset($_POST['DefaultGateway']) && $_POST['DefaultGateway'] !== '') {
       $cfg[] = 'static routers='.$_POST['DefaultGateway'];
     }
     if ($_POST['DNS1'] !== '' || $_POST['DNS2'] !== '') {

--- a/includes/dhcp.php
+++ b/includes/dhcp.php
@@ -271,6 +271,11 @@ function updateDHCPConfig($iface,$status)
         $cfg[] = 'fallback static_'.$iface;
     }
     $cfg[] = $_POST['DefaultRoute'] == '1' ? 'gateway' : 'nogateway';
+
+    if (substr($iface, 0, 2) === "wl") {
+        $cfg[] = $_POST['HookWPASupplicant'] == '1' ? 'hook wpa_supplicant' : 'nohook wpa_supplicant';
+    }
+
     $dhcp_cfg = file_get_contents(RASPI_DHCPCD_CONFIG);
     if (!preg_match('/^interface\s'.$iface.'$/m', $dhcp_cfg)) {
         $cfg[] = PHP_EOL;

--- a/templates/dhcp/general.php
+++ b/templates/dhcp/general.php
@@ -71,7 +71,7 @@
     <div class="form-group col-md-6">
         <div class="custom-control custom-switch">
           <input class="custom-control-input" id="hook-wpa-supplicant" type="checkbox" name="HookWPASupplicant" value="1" aria-describedby="hook-wpa-supplicant-description">
-          <label class="custom-control-label" for="hook-wpa-supplicant"><?php echo _("Enable/Disable WPA_Supplicant dhcp hook for this interface") ?></label>
+          <label class="custom-control-label" for="hook-wpa-supplicant"><?php echo _("Enable WPA_Supplicant dhcp hook for this interface") ?></label>
         </div>
         <p class="mb-0" id="hook-wpa-supplicant-description">
           <small><?php echo _("This toggles the <code>hook wpa_supplicant</code>/<code>nohook wpa_supplicant</code> option for this interface in the DHCPCD configuration.") ?></small>

--- a/templates/dhcp/general.php
+++ b/templates/dhcp/general.php
@@ -67,6 +67,18 @@
     </div>
   </div>
 
+  <div class="row">
+    <div class="form-group col-md-6">
+        <div class="custom-control custom-switch">
+          <input class="custom-control-input" id="hook-wpa-supplicant" type="checkbox" name="HookWPASupplicant" value="1" aria-describedby="hook-wpa-supplicant-description">
+          <label class="custom-control-label" for="hook-wpa-supplicant"><?php echo _("Enable/Disable WPA_Supplicant dhcp hook for this interface") ?></label>
+        </div>
+        <p class="mb-0" id="hook-wpa-supplicant-description">
+          <small><?php echo _("This toggles the <code>hook wpa_supplicant</code>/<code>nohook wpa_supplicant</code> option for this interface in the DHCPCD configuration.") ?></small>
+        </p>
+    </div>
+  </div>
+
   <h5 class="mt-1">DHCP options</h5>
   <div class="row">
     <div class="form-group col-md-6">


### PR DESCRIPTION
Created to address https://github.com/RaspAP/raspap-insiders/issues/168

Adds logic to check if the dhcp interface selected starts with "wl" or not and if so it adds conditional log to check if nohook wpa_supplicant or hook wpa_supplicant should be written to /etc/dhcpcd.conf or not

I also updated the matching logic for get_netcfg.php to not accidentally read into the next net block and interpret flags set for a different interface

Previous logic read to end of doc and so if wlan0 and wlan1 existed but wlan1 had gateway configured but it did not exist in wlan0 it would still show up

The updated logic checks now for either end of doc or # RaspAP