### PR TITLE
Correctly handle 64 hex digit passkey 

### DIFF
--- a/includes/configure_client.php
+++ b/includes/configure_client.php
@@ -82,6 +82,9 @@ function DisplayWPAConfig()
                         fwrite($wpa_file, "network={".PHP_EOL);
                         fwrite($wpa_file, "\tssid=\"".$ssid."\"".PHP_EOL);
                         fwrite($wpa_file, $line.PHP_EOL);
+                        if (array_key_exists('priority', $network)) {
+                            fwrite($wpa_file, "\tpriority=".$network['priority'].PHP_EOL);
+                        }
                         fwrite($wpa_file, "}".PHP_EOL);
                     } else {
                         $status->addMessage('WPA passphrase must be between 8 and 63 characters', 'danger');

--- a/includes/configure_client.php
+++ b/includes/configure_client.php
@@ -77,6 +77,12 @@ function DisplayWPAConfig()
                                 }
                             }
                         }
+                    } elseif (strlen($network['passphrase']) == 0 && strlen($network['passkey']) == 64) {
+                        $line = "\tpsk=" . $network['passkey'];
+                        fwrite($wpa_file, "network={".PHP_EOL);
+                        fwrite($wpa_file, "\tssid=\"".$ssid."\"".PHP_EOL);
+                        fwrite($wpa_file, $line.PHP_EOL);
+                        fwrite($wpa_file, "}".PHP_EOL);
                     } else {
                         $status->addMessage('WPA passphrase must be between 8 and 63 characters', 'danger');
                         $ok = false;

--- a/includes/wifi_functions.php
+++ b/includes/wifi_functions.php
@@ -27,9 +27,9 @@ function knownWifiStations(&$networks)
                     $network['ssid'] = $ssid;
                     break;
                 case 'psk':
-                    if (array_key_exists('passphrase', $network)) {
-                        break;
-                    }
+                    $network['passkey'] = trim($lineArr[1]);
+                    $network['protocol'] = 'WPA';
+                    break;
                 case '#psk':
                     $network['protocol'] = 'WPA';
                 case 'wep_key0': // Untested


### PR DESCRIPTION
A network defined in wpa_supplicant.conf may contain a passphrase, passkey or both. In cases where a known network exists with a valid 64-character passkey, but no passphrase, RaspAP will incorrectly throw a 'WPA passphrase must be between 8 and 63 characters' error.

Resolves #1397

```
# psk: WPA preshared key; 256-bit pre-shared key
# The key used in WPA-PSK mode can be entered either as 64 hex-digits, i.e.,
# 32 bytes or as an ASCII passphrase (in which case, the real PSK will be
# generated using the passphrase and SSID). ASCII passphrase must be between
# 8 and 63 characters (inclusive). ext:<name of external PSK field> format can
# be used to indicate that the PSK/passphrase is stored in external storage.
```
https://w1.fi/cgit/hostap/plain/wpa_supplicant/wpa_supplicant.conf