### PR TITLE
Install dhcpcd dependencies for GNU/Linux 12 (bookworm) 32-bit

### DIFF
--- a/installers/common.sh
+++ b/installers/common.sh
@@ -135,6 +135,17 @@ function _get_linux_distro() {
     else
         _install_status 1 "Unsupported Linux distribution"
     fi
+
+    if [ ${OS,,} = "raspbian" ] && [[ ${RELEASE} =~ ^(12) ]]; then
+        echo "Detected OS: ${DESC} 32-bit"
+        echo "This OS introduces breaking changes to dhcpcd and is unsupported."
+        echo "If Raspberry Pi OS Lite (32-bit) is wanted, downgrade to bullseye."
+        echo "Note: Raspbian GNU/Linux 12 (bookworm) 64-bit is fully supported."
+        echo "See: https://docs.raspap.com/#compatible-operating-systems"
+        echo "The installer cannot continue."
+        _install_status 1 "Unsupported Linux distribution"
+        exit 0
+    fi
 }
 
 # Sets php package option based on Linux version, abort if unsupported distro
@@ -228,6 +239,7 @@ function _install_dependencies() {
     if [ ${OS,,} = "debian" ] || [ ${OS,,} = "ubuntu" ]; then
         dhcpcd_package="dhcpcd5"
         iw_package="iw"
+        echo "${dhcpcd_package} and ${iw_package} will be installed from the main deb sources list"
     fi
 
     # Set dconf-set-selections

--- a/installers/common.sh
+++ b/installers/common.sh
@@ -135,17 +135,6 @@ function _get_linux_distro() {
     else
         _install_status 1 "Unsupported Linux distribution"
     fi
-
-    if [ ${OS,,} = "raspbian" ] && [[ ${RELEASE} =~ ^(12) ]]; then
-        echo "Detected OS: ${DESC} 32-bit"
-        echo "This OS introduces breaking changes to dhcpcd and is unsupported."
-        echo "If Raspberry Pi OS Lite (32-bit) is wanted, downgrade to bullseye."
-        echo "Note: Raspbian GNU/Linux 12 (bookworm) 64-bit is fully supported."
-        echo "See: https://docs.raspap.com/#compatible-operating-systems"
-        echo "The installer cannot continue."
-        _install_status 1 "Unsupported Linux distribution"
-        exit 0
-    fi
 }
 
 # Sets php package option based on Linux version, abort if unsupported distro
@@ -240,6 +229,11 @@ function _install_dependencies() {
         dhcpcd_package="dhcpcd5"
         iw_package="iw"
         echo "${dhcpcd_package} and ${iw_package} will be installed from the main deb sources list"
+    fi
+
+    if [ ${OS,,} = "raspbian" ] && [[ ${RELEASE} =~ ^(12) ]]; then
+        dhcpcd_package="dhcpcd dhcpcd-base"
+        echo "${dhcpcd_package} will be installed from the main deb sources list"
     fi
 
     # Set dconf-set-selections
@@ -569,6 +563,7 @@ function _check_for_old_configs() {
                 sudo ln -sf "${raspap_dir}/backups/${filename}.`date +%F-%R`" "${raspap_dir}/backups/${filename}"
             fi
         done
+
     fi
     _install_status 0
 }
@@ -604,7 +599,16 @@ function _default_configuration() {
         if [ ! -f "$webroot_dir/includes/config.php" ]; then
             sudo cp "$webroot_dir/config/config.php" "$webroot_dir/includes/config.php"
         fi
+
+        if [ ${OS,,} = "raspbian" ] && [[ ${RELEASE} =~ ^(12) ]]; then
+            echo "Moving dhcpcd systemd unit control file to /lib/systemd/system/"
+            sudo mv $webroot_dir/installers/dhcpcd.service /lib/systemd/system/ || _install_status 1 "Unable to move dhcpcd.service file"
+            sudo systemctl daemon-reload
+            sudo systemctl enable dhcpcd.service || _install_status 1 "Failed to enable raspap.service"
+        fi
+
         _install_status 0
+        exit 0
     fi
 }
 

--- a/installers/common.sh
+++ b/installers/common.sh
@@ -563,7 +563,6 @@ function _check_for_old_configs() {
                 sudo ln -sf "${raspap_dir}/backups/${filename}.`date +%F-%R`" "${raspap_dir}/backups/${filename}"
             fi
         done
-
     fi
     _install_status 0
 }
@@ -608,7 +607,6 @@ function _default_configuration() {
         fi
 
         _install_status 0
-        exit 0
     fi
 }
 

--- a/installers/dhcpcd.service
+++ b/installers/dhcpcd.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=DHCP Client Daemon
+Wants=network.target
+Before=network-online.target
+Documentation=man:dhcpcd(8)
+
+[Service]
+Type=forking
+ExecStart=/usr/sbin/dhcpcd -b -q
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
This distro's support for dhcpcd is badly broken. After installing the `dhcpcd` package from apt, dependencies to run it are missing:

```
/usr/sbin/dhcpcd: line 104: /sbin/dhcpcd-bin: cannot execute: required file not found
```

~~This PR simply detects this release and halts with a message to this effect.~~
A missing dependency `dhcpcd-base` and systemd unit control file are installed with this PR.

Related discussion #1422 