### PR TITLE
Fix: add AP interface to vnstat for monitoring

### DIFF
--- a/includes/dashboard.php
+++ b/includes/dashboard.php
@@ -88,6 +88,11 @@ function DisplayDashboard(&$extraFooterScripts)
         $strTxBytes .= getHumanReadableDatasize($strTxBytes);
     }
 
+    exec ('vnstat --dbiflist', $stdoutVnStatDB);
+    if (!preg_match('/'.$_SESSION['ap_interface'].'/', $stdoutVnStatDB[0])) {
+        exec('sudo vnstat --add --iface '.$_SESSION['ap_interface'], $return);
+    }
+
     define('SSIDMAXLEN', 32);
     // Warning iw comes with: "Do NOT screenscrape this tool, we don't consider its output stable."
     exec('iw dev ' .$_SESSION['wifi_client_interface']. ' link ', $stdoutIw);

--- a/installers/raspap.sudoers
+++ b/installers/raspap.sudoers
@@ -64,3 +64,4 @@ www-data ALL=(ALL) NOPASSWD:/bin/rm /etc/wireguard/*.conf
 www-data ALL=(ALL) NOPASSWD:/bin/rm /etc/wireguard/wg-*.key
 www-data ALL=(ALL) NOPASSWD:/usr/sbin/netplan
 www-data ALL=(ALL) NOPASSWD:/bin/truncate -s 0 /tmp/*.log,/bin/truncate -s 0 /var/log/dnsmasq.log
+www-data ALL=(ALL) NOPASSWD:/usr/bin/vnstat *


### PR DESCRIPTION
In some cases, the dashboard and data usage graphs will appear empty for the AP interface eg., when an external adapter is used. This checks vnstat's db and explicitly adds it to the list of monitored interfaces.

Raspbian GNU/Linux 12 (bookworm)
vnStat 2.10