### PR TITLE
Fix: prevent duplicate array values in ParseConfig()

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -427,6 +427,7 @@ function ParseConfig($arrConfig)
     foreach ($arrConfig as $line) {
         $line = trim($line);
         if ($line == "" || $line[0] == "#") {
+            $config[$option] = null;
             continue;
         }
 


### PR DESCRIPTION
Ignored config entries (blank lines or "#" comments) result in a duplicate array values for preceding entries, eg.:

```
[DNS] => Array
    (
        [0] => 10.64.0.1
        [1] => 10.64.0.1
    )
```

Probably due to a change in PHP 8's internal array handling, as this was not observed in PHP 7.x.