### PR TITLE
Parse /etc/os-release directly (compatibility)

### DIFF
--- a/src/RaspAP/System/Sysinfo.php
+++ b/src/RaspAP/System/Sysinfo.php
@@ -83,7 +83,7 @@ class Sysinfo
 
     public function operatingSystem()
     {
-        $os_desc = shell_exec("lsb_release -sd");
+        $os_desc = shell_exec("cat /etc/os-release | awk -F= '/^PRETTY_NAME/ {print $2}' | sed 's/\"//g'");
         return $os_desc;
     }
 


### PR DESCRIPTION
Minimal distros such as those used by RaspAP/raspap-docker do not have `lsb_release`.
This fixes the empty "OS" field on the System > Basic tab.