### PR TITLE
Fix get/set admin username

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -5,6 +5,7 @@ function DisplayAuthConfig($username)
     $status = new \RaspAP\Messages\StatusMessage;
     $auth = new \RaspAP\Auth\HTTPAuth;
     $config = $auth->getAuthConfig();
+    $username = $config['admin_user'];
     $password = $config['admin_pass'];
 
     if (isset($_POST['UpdateAdminPassword'])) {

--- a/src/RaspAP/Auth/HTTPAuth.php
+++ b/src/RaspAP/Auth/HTTPAuth.php
@@ -96,6 +96,7 @@ class HTTPAuth
             if ($auth_details = fopen(RASPI_CONFIG . '/raspap.auth', 'r')) {
                 $config['admin_user'] = trim(fgets($auth_details));
                 $config['admin_pass'] = trim(fgets($auth_details));
+                $_SESSION['user_id'] = $config['admin_user'];
                 fclose($auth_details);
             }
         }


### PR DESCRIPTION
The admin username is stored in `raspap.auth`, but not displayed in the top navbar. Simple fix resolves this.