### PR TITLE
Critical security fixes 

### DIFF
--- a/ajax/adblock/update_blocklist.php
+++ b/ajax/adblock/update_blocklist.php
@@ -2,6 +2,7 @@
 
 require '../../includes/csrf.php';
 require_once '../../includes/config.php';
+require_once '../../includes/authenticate.php';
 
 if (isset($_POST['blocklist_id'])) {
     $blocklist_id = escapeshellcmd($_POST['blocklist_id']);
@@ -50,4 +51,3 @@ if (isset($_POST['blocklist_id'])) {
     $jsonData = ['return'=>2,'output'=>['Error getting data']];
     echo json_encode($jsonData);
 }
-

--- a/ajax/bandwidth/get_bandwidth.php
+++ b/ajax/bandwidth/get_bandwidth.php
@@ -3,6 +3,7 @@
 require '../../includes/csrf.php';
 
 require_once '../../includes/config.php';
+require_once '../../includes/authenticate.php';
 
 $interface = filter_input(INPUT_GET, 'inet', FILTER_SANITIZE_SPECIAL_CHARS);
 if (empty($interface)) {
@@ -13,8 +14,7 @@ if (empty($interface)) {
     } else {
         exit('No network interfaces found.');
     }
-} 
-
+}
 define('IFNAMSIZ', 16);
 if (strlen($interface) > IFNAMSIZ) {
     exit('Interface name too long.');
@@ -72,14 +72,12 @@ for ($i = count($jsonData) - 1; $i >= 0; --$i) {
     $datareceived = round($jsonData[$i]['rx'] / $dsu_factor, 0);
 
     if ($timeunits === 'm') {
-        echo '{ "date": "' , $dt->format('Y-m') , '", "rx": "' , $datareceived , 
+        echo '{ "date": "' , $dt->format('Y-m') , '", "rx": "' , $datareceived ,
         '", "tx": "' , $datasend , '" }';
     } else {
-        echo '{ "date": "' , $dt->format('Y-m-d') , '", "rx": "' , $datareceived , 
+        echo '{ "date": "' , $dt->format('Y-m-d') , '", "rx": "' , $datareceived ,
         '", "tx": "' , $datasend , '" }';
     }
 }
 
 echo ' ]';
-
-

--- a/ajax/bandwidth/get_bandwidth_hourly.php
+++ b/ajax/bandwidth/get_bandwidth_hourly.php
@@ -1,6 +1,8 @@
-<?php 
+<?php
 
 require '../../includes/csrf.php';
+require_once '../../includes/config.php';
+require_once '../../includes/authenticate.php';
 
 if (filter_input(INPUT_GET, 'tu') == 'h') {
 

--- a/ajax/logging/clearlog.php
+++ b/ajax/logging/clearlog.php
@@ -2,10 +2,11 @@
 
 require '../../includes/csrf.php';
 require_once '../../includes/config.php';
+require_once '../../includes/authenticate.php';
 require_once '../../includes/functions.php';
 
 if (isset($_POST['logfile'])) {
-    $logfile = escapeshellcmd($_POST['logfile']);
+    $logfile = escapeshellarg($_POST['logfile']);
 
     // truncate requested log file
     exec("sudo truncate -s 0 $logfile", $return);

--- a/ajax/networking/do_sys_reset.php
+++ b/ajax/networking/do_sys_reset.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once '../../includes/config.php';
+require_once '../../includes/authenticate.php';
 require_once '../../includes/session.php';
 require_once '../../includes/functions.php';
 
@@ -16,7 +17,7 @@ if (isset($_POST['csrf_token'])) {
         array("src" => $path .'/090_wlan0.conf', "tmp" => "/tmp/dnsmasqdata", "dest" => RASPI_DNSMASQ_PREFIX.'wlan0.conf'),
         array("src" => $path .'/090_raspap.conf', "tmp" => "/tmp/dnsmasqdata", "dest" => RASPI_DNSMASQ_PREFIX.'raspap.conf'),
     );
-    
+
     foreach ($configs as $config) {
         try {
             $tmp = file_get_contents($config["src"]);
@@ -32,4 +33,3 @@ if (isset($_POST['csrf_token'])) {
 } else {
     handleInvalidCSRFToken();
 }
-

--- a/ajax/networking/get_all_interfaces.php
+++ b/ajax/networking/get_all_interfaces.php
@@ -1,6 +1,8 @@
 <?php
 
 require '../../includes/csrf.php';
+require_once '../../includes/config.php';
+require_once '../../includes/authenticate.php';
 
 exec("ls /sys/class/net | grep -v lo", $interfaces);
 echo json_encode($interfaces);

--- a/ajax/networking/get_channel.php
+++ b/ajax/networking/get_channel.php
@@ -2,6 +2,7 @@
 
 require '../../includes/csrf.php';
 require_once '../../includes/config.php';
+require_once '../../includes/authenticate.php';
 
 exec('cat '. RASPI_HOSTAPD_CONFIG, $hostapdconfig);
 $arrConfig = array();

--- a/ajax/networking/get_frequencies.php
+++ b/ajax/networking/get_frequencies.php
@@ -1,6 +1,8 @@
 <?php
 
 require '../../includes/csrf.php';
+require_once '../../includes/config.php';
+require_once '../../includes/authenticate.php';
 require '../../src/RaspAP/Parsers/IwParser.php';
 
 if (isset($_POST['interface'])) {
@@ -11,4 +13,3 @@ if (isset($_POST['interface'])) {
 
     echo json_encode($supportedFrequencies);
 }
-

--- a/ajax/networking/get_ip_summary.php
+++ b/ajax/networking/get_ip_summary.php
@@ -3,6 +3,8 @@
 require '../../includes/csrf.php';
 
 require_once '../../includes/functions.php';
+require_once '../../includes/config.php';
+require_once '../../includes/authenticate.php';
 
 if (isset($_POST['interface'])) {
     $int = preg_replace('/[^a-z0-9]/', '', $_POST['interface']);

--- a/ajax/networking/get_netcfg.php
+++ b/ajax/networking/get_netcfg.php
@@ -2,8 +2,9 @@
 
 require '../../includes/csrf.php';
 require_once '../../includes/config.php';
+require_once '../../includes/authenticate.php';
 
-$interface = $_GET['iface'];
+$interface = $_POST['iface'];
 
 if (isset($interface)) {
     // fetch dnsmasq.conf settings for interface

--- a/ajax/networking/get_nl80211_band.php
+++ b/ajax/networking/get_nl80211_band.php
@@ -2,13 +2,20 @@
 
 require '../../includes/csrf.php';
 require_once '../../includes/config.php';
+require_once '../../includes/authenticate.php';
 require_once '../../includes/locale.php';
 
 if (isset($_POST['interface'])) {
 
     define( 'NL80211_BAND_24GHZ', 0x1 );
     define( 'NL80211_BAND_5GHZ', 0x2 );
+
+    if(!preg_match('/^[a-zA-Z0-9]+$/', $_POST['interface'])) {
+      exit('Invalid interface name.');
+    }
+
     $iface = escapeshellcmd($_POST['interface']);
+
     $flags = 0;
 
     // get physical device for selected interface
@@ -17,7 +24,7 @@ if (isset($_POST['interface'])) {
 
     // get frequencies supported by device
     exec('iw '.$phy.' info | sed -rn "s/^.*\*\s([0-9]{4})\sMHz.*/\1/p"', $frequencies);
-    
+
     if (count(preg_grep('/^24[0-9]{2}/i', $frequencies)) >0) {
         $flags += NL80211_BAND_24GHZ;
     }
@@ -40,4 +47,3 @@ if (isset($_POST['interface'])) {
     }
     echo json_encode($msg);
 }
-

--- a/ajax/networking/get_wgcfg.php
+++ b/ajax/networking/get_wgcfg.php
@@ -2,8 +2,8 @@
 
 require '../../includes/csrf.php';
 require_once '../../includes/config.php';
+require_once '../../includes/authenticate.php';
 
 // fetch wg client.conf
 exec('sudo cat '. RASPI_WIREGUARD_PATH.'client.conf', $return);
 echo implode(PHP_EOL,$return);
-

--- a/ajax/networking/get_wgkey.php
+++ b/ajax/networking/get_wgkey.php
@@ -2,17 +2,18 @@
 
 require '../../includes/csrf.php';
 require_once '../../includes/config.php';
+require_once '../../includes/authenticate.php';
 
 $entity = escapeshellcmd($_POST['entity']);
 
 if (isset($entity)) {
-   
+
     // generate public/private key pairs for entity
     $pubkey = RASPI_WIREGUARD_PATH.$entity.'-public.key';
     $privkey = RASPI_WIREGUARD_PATH.$entity.'-private.key';
     $pubkey_tmp = '/tmp/'.$entity.'-public.key';
     $privkey_tmp = '/tmp/'.$entity.'-private.key';
-     
+
     exec("sudo wg genkey | tee $privkey_tmp | wg pubkey > $pubkey_tmp", $return);
     $wgdata['pubkey'] = str_replace("\n",'',file_get_contents($pubkey_tmp));
     exec("sudo mv $privkey_tmp $privkey", $return);

--- a/ajax/networking/wifi_stations.php
+++ b/ajax/networking/wifi_stations.php
@@ -2,6 +2,7 @@
 
 require '../../includes/csrf.php';
 require_once '../../includes/config.php';
+require_once '../../includes/authenticate.php';
 require_once '../../includes/defaults.php';
 require_once '../../includes/functions.php';
 require_once '../../includes/wifi_functions.php';
@@ -14,7 +15,7 @@ knownWifiStations($networks);
 nearbyWifiStations($networks, !isset($_REQUEST["refresh"]));
 connectedWifiStations($networks);
 sortNetworksByRSSI($networks);
-foreach ($networks as $ssid => $network) $networks[$ssid]["ssidutf8"] = ssid2utf8( $ssid ); 
+foreach ($networks as $ssid => $network) $networks[$ssid]["ssidutf8"] = ssid2utf8( $ssid );
 
 $connected = array_filter($networks, function($n) { return $n['connected']; } );
 $known     = array_filter($networks, function($n) { return !$n['connected'] && $n['configured']; } );

--- a/ajax/openvpn/activate_ovpncfg.php
+++ b/ajax/openvpn/activate_ovpncfg.php
@@ -2,6 +2,7 @@
 
 require '../../includes/csrf.php';
 require_once '../../includes/config.php';
+require_once '../../includes/authenticate.php';
 require_once '../../includes/functions.php';
 
 if (isset($_POST['cfg_id'])) {
@@ -24,4 +25,3 @@ if (isset($_POST['cfg_id'])) {
 
     echo json_encode($return);
 }
-

--- a/ajax/openvpn/del_ovpncfg.php
+++ b/ajax/openvpn/del_ovpncfg.php
@@ -2,6 +2,7 @@
 
 require '../../includes/csrf.php';
 require_once '../../includes/config.php';
+require_once '../../includes/authenticate.php';
 require_once '../../includes/functions.php';
 
 if (isset($_POST['cfg_id'])) {
@@ -11,4 +12,3 @@ if (isset($_POST['cfg_id'])) {
     $jsonData = ['return'=>$return];
     echo json_encode($jsonData);
 }
-

--- a/ajax/system/sys_actions.php
+++ b/ajax/system/sys_actions.php
@@ -1,6 +1,8 @@
 <?php
 
 require '../../includes/csrf.php';
+require_once '../../includes/config.php';
+require_once '../../includes/authenticate.php';
 
 $action = escapeshellcmd($_POST['a']);
 
@@ -18,4 +20,3 @@ if (isset($action)) {
     }
     echo json_encode($response);
 }
-

--- a/ajax/system/sys_debug.php
+++ b/ajax/system/sys_debug.php
@@ -2,6 +2,7 @@
 
 require '../../includes/csrf.php';
 require_once '../../includes/config.php';
+require_once '../../includes/authenticate.php';
 
 if (isset($_POST['csrf_token'])) {
     if (csrfValidateRequest() && !CSRFValidate()) {
@@ -20,4 +21,3 @@ if (isset($_POST['csrf_token'])) {
 } else {
     handleInvalidCSRFToken();
 }
-

--- a/ajax/system/sys_get_logfile.php
+++ b/ajax/system/sys_get_logfile.php
@@ -1,7 +1,8 @@
-<?php 
+<?php
 
 require '../../includes/csrf.php';
 require_once '../../includes/config.php';
+require_once '../../includes/authenticate.php';
 
 $tempDir = sys_get_temp_dir();
 $filePath = $tempDir . DIRECTORY_SEPARATOR . RASPI_DEBUG_LOG;
@@ -19,4 +20,3 @@ if (isset($filePath)) {
     header('Location: '.'/system_info');
     exit();
 }
-

--- a/ajax/system/sys_perform_update.php
+++ b/ajax/system/sys_perform_update.php
@@ -1,6 +1,8 @@
 <?php
 
 require '../../includes/csrf.php';
+require_once '../../includes/config.php';
+require_once '../../includes/authenticate.php';
 
 if (isset($_POST['csrf_token'])) {
     if (csrfValidateRequest() && !CSRFValidate()) {
@@ -18,4 +20,3 @@ if (isset($_POST['csrf_token'])) {
 } else {
     handleInvalidCSRFToken();
 }
-

--- a/ajax/system/sys_read_logfile.php
+++ b/ajax/system/sys_read_logfile.php
@@ -1,5 +1,8 @@
 <?php
 
+require_once '../../includes/config.php';
+require_once '../../includes/authenticate.php';
+
 $logFile = '/tmp/raspap_install.log';
 $searchStrings = [
     'Configure update' => 1,
@@ -40,4 +43,3 @@ if (file_exists($logFile)) {
 } else {
     echo json_encode("File does not exist: $logFile");
 }
-

--- a/app/js/custom.js
+++ b/app/js/custom.js
@@ -216,7 +216,7 @@ Option toggles are set dynamically depending on the loaded configuration
 */
 function loadInterfaceDHCPSelect() {
     var strInterface = $('#cbxdhcpiface').val();
-    $.get('ajax/networking/get_netcfg.php?iface='+strInterface,function(data){
+    $.post('ajax/networking/get_netcfg.php', {iface : strInterface}, function(data){
         jsonData = JSON.parse(data);
         $('#dhcp-iface')[0].checked = jsonData.DHCPEnabled;
         $('#txtipaddress').val(jsonData.StaticIP);
@@ -752,14 +752,14 @@ $(document).on("click", ".js-toggle-password", function(e) {
 
 $(function() {
     $('#theme-select').change(function() {
-        var theme = themes[$( "#theme-select" ).val() ]; 
+        var theme = themes[$( "#theme-select" ).val() ];
         set_theme(theme);
    });
 });
 
 function set_theme(theme) {
     $('link[title="main"]').attr('href', 'app/css/' + theme);
-    // persist selected theme in cookie 
+    // persist selected theme in cookie
     setCookie('theme',theme,90);
 }
 
@@ -772,7 +772,7 @@ $(function() {
     $('#night-mode').change(function() {
         var state = $(this).is(':checked');
         var currentTheme = getCookie('theme');
-        
+
         if (state == true) {
             if (currentTheme == 'custom.php') {
                 set_theme('lightsout.php');


### PR DESCRIPTION
Any device on the network, or anyone with access to the RaspAP web page from upstream of RaspAP, would be able to take over the host running RaspAP and run arbitrary commands.

With the flaws I could also
- bypass the authentication password
- brick the system

This pull requests addresses some issues. Likely there are more post auth but this PR reduces the preauthenticated attack surface.  However, the UI fix to support this is not yet complete and needs to be implemented by raspap. The Ajax JS calls need a rewrite to pass along credentials. Most likely a static html login page is needed, followed by an update to the ajax code to do something like:

```
$.ajaxSetup({
  headers: {
    'Authorization': "Basic " + btoa(USERNAME + ":" + PASSWORD)
  }
});
```


it was also noticed that raspap limits people's ability to use wpa3 by default, this seems like a poor choice. SAE is not a perfect PAKE, but its a lot better than WPA2.