### PR TITLE
Use sed instead of grep+cut to capture the passphrase

### DIFF
--- a/api/modules/ap.py
+++ b/api/modules/ap.py
@@ -32,7 +32,7 @@ def ieee80211n():
     return subprocess.run("cat /etc/hostapd/hostapd.conf | grep ieee80211n= | cut -d'=' -f2", shell=True, capture_output=True, text=True).stdout.strip()
 
 def wpa_passphrase():
-    return subprocess.run("cat /etc/hostapd/hostapd.conf | grep wpa_passphrase= | cut -d'=' -f2", shell=True, capture_output=True, text=True).stdout.strip()
+    return subprocess.run("sed -En 's/wpa_passphrase=(.*)/\1/p' /etc/hostapd/hostapd.conf", shell=True, capture_output=True, text=True).stdout.strip()
 
 def interface():
     return subprocess.run("cat /etc/hostapd/hostapd.conf | grep interface= | cut -d'=' -f2 | head -1", shell=True, capture_output=True, text=True).stdout.strip()


### PR DESCRIPTION
Current method would crop any passphrase containing an `=` sign.

For eg. with this `hostapd.conf`:

> ...
> wpa_passwphrase=Foo=Bar
> ...

the `wpa_passphrase()` function would would return `Foo` instead of `Foo=Bar`, incorrectly cropping the
passkey.

As a result, when editing the hotspot settings, the user may incorrectly update its passkey without even knowing it.
Luckily, mine was cropped to a too short string, so I noticed the error in the form.

I tested the new command with macOS & Linux (Debian) so I guess it should work with most Unix OS.

Also, I guess the problem can happen in other places, like maybe with the `ssid` (can it contain `=` signs?).