### PR TITLE
fix: Increase curl max-time to 15 seconds for connectivity check

### DIFF
--- a/installers/raspbian.sh
+++ b/installers/raspbian.sh
@@ -299,7 +299,7 @@ function _check_internet() {
     tput civis # hide cursor
 
     # run check in background
-    ( curl -Is --connect-timeout 3 --max-time 5 https://github.com | head -n 1 | grep "HTTP/2 200" >/dev/null ) &
+    ( curl -Is --connect-timeout 3 --max-time 15 https://github.com | head -n 1 | grep "HTTP/2 200" >/dev/null ) &
     local pid=$!
 
     # display spinner while curl runs


### PR DESCRIPTION
This PR increases the maximum time allowed for the GitHub connectivity check from 5 to 15 seconds. This provides more time for the connection to complete in environments with slower internet connections, reducing false negatives in the connectivity check.