### PR TITLE
Bug #1762

### DIFF
--- a/src/RaspAP/Parsers/IwParser.php
+++ b/src/RaspAP/Parsers/IwParser.php
@@ -47,7 +47,7 @@ class IwParser
             "(no IR)"
         ];
         $excluded_pattern = implode('|', array_map('preg_quote', $excluded));
-        $pattern = '/\*\s+(\d+)\s+MHz \[(\d+)\] \(([\d.]+) dBm\)\s(?!' .$excluded_pattern. ')/';
+        $pattern = '/\*\s+([\d.]+)\s+MHz \[(\d+)\] \(([\d.]+) dBm\)\s(?!' .$excluded_pattern. ')/';
         $supportedFrequencies = [];
 
         // Match iw_output containing supported frequencies


### PR DESCRIPTION
New versions of 'iw phy#0 info' provides frequencies output with decimals #1762. IW Parser patched to handle this new output format