### PR TITLE
Extends PluginInstaller w/ setFilePermissions()

### DIFF
--- a/installers/plugin_helper.sh
+++ b/installers/plugin_helper.sh
@@ -78,6 +78,25 @@ case "$action" in
     echo "OK"
     ;;
 
+  "permissions")
+    [ $# -lt 4 ] && { echo "Usage: $0 permissions <filepath> <user> <group> <mode>"; exit 1; }
+
+    filepath="$1"
+    user="$2"
+    group="$3"
+    mode="$4"
+
+    if [ ! -e "$filepath" ]; then
+        echo "File not found: $filepath" >&2
+        exit 1
+    fi
+
+    chown "$user:$group" "$filepath" || exit 1
+    chmod "$mode" "$filepath" || exit 1
+
+    echo "OK"
+    ;;
+
   "javascript")
     [ $# -lt 2 ] && { echo "Usage: $0 javascript <source> <destination>"; exit 1; }
 

--- a/src/RaspAP/Plugins/PluginInstaller.php
+++ b/src/RaspAP/Plugins/PluginInstaller.php
@@ -205,6 +205,10 @@ class PluginInstaller
                     $this->copyConfigFiles($manifest['configuration'], $pluginDir);
                     $rollbackStack[] = 'removeConfigFiles';
                 }
+                if (!empty($manifest['permissions'])) {
+                    $this->setFilePermissions($manifest['permissions']);
+                    $rollbackStack[] = 'revertFilePermissions';
+                }
                 if (!empty($manifest['javascript'])) {
                     $this->copyJavaScriptFiles($manifest['javascript'], $pluginDir);
                     $rollbackStack[] = 'removeJavaScript';
@@ -315,6 +319,38 @@ class PluginInstaller
             $return = shell_exec($cmd);
             if (strpos(strtolower($return), 'ok') === false) {
                 throw new \Exception("Failed to copy configuration file: $source to $destination");
+            }
+        }
+    }
+
+    /**
+     * Sets permissions on a specified file, including owner/group and mode
+     *
+     * @param array $permissions): void
+     */
+    private function setFilePermissions(array $permissions): void
+    {
+        foreach ($permissions as $entry) {
+            $file = $entry['file'] ?? null;
+            $owner = $entry['owner'] ?? null;
+            $group = $entry['group'] ?? null;
+            $mode = $entry['mode'] ?? null;
+
+            if (!$file || !$owner || !$group || !$mode) {
+                error_log("Incomplete permission entry for file: " . json_encode($entry));
+                continue;
+            }
+
+            $cmd = escapeshellcmd('sudo '.RASPI_CONFIG.'/plugins/plugin_helper.sh') .
+                ' permissions ' .
+                escapeshellarg($file) .' '.
+                escapeshellarg($owner) .' '.
+                escapeshellarg($group) .' '.
+                escapeshellarg($mode);
+            exec($cmd . ' 2>&1', $output, $return);
+
+            if ($return !== 0) {
+                throw new \Exception("Failed to set permissions on $file: " . implode("\n", $output));
             }
         }
     }
@@ -503,7 +539,7 @@ class PluginInstaller
                     name="install-plugin" data-bs-toggle="modal" data-bs-target="#install-user-plugin"
                     data-plugin-manifest="' .$manifest. '" data-repo-public="' .$this->repoPublic. '">' . _("Details") .'</button>';
             }
-
+    
             $icon = htmlspecialchars($manifestData['icon'] ?? '');
             $pluginDocs = htmlspecialchars($manifestData['plugin_docs'] ?? '');
             $nameText = htmlspecialchars($manifestData['name'] ?? 'Unknown Plugin');
@@ -511,7 +547,6 @@ class PluginInstaller
                 .$pluginDocs
                 .'" target="_blank">'
                 .$nameText. '</a>';
-
             $version = htmlspecialchars($manifestData['version'] ?? 'N/A');
             $description = htmlspecialchars($manifestData['description'] ?? 'No description available');
 

--- a/templates/system.php
+++ b/templates/system.php
@@ -149,7 +149,6 @@
             <tr>
               <th><?php echo _("Configuration files"); ?></th>
               <td><small><code><span id="plugin-configuration" class="mb-0"></span></code></small></td>
-              </td>
             </tr>
             <tr>
               <th><?php echo _("Signed Packages"); ?></th>
@@ -164,7 +163,7 @@
               <td><small><code><span id="plugin-javascript" class="mb-0"></span></code></small></td>
             </tr>
             <tr>
-              <th><?php echo _("Permissions"); ?></th>
+              <th><?php echo _("Sudoers"); ?></th>
               <td><small><code><span id="plugin-sudoers" class="mb-0"></span></code></small></td>
             </tr>
             <tr>


### PR DESCRIPTION
Parses an optional "permissions" key from `manifest.json` to set file owner, group and mode. e.g.:

```
"permissions": [
   {
      "file": "/etc/raspap/somefile.sh",
      "owner": "www-data",
      "group": "www-data",
      "mode": "0755"
    },
]
```