### PR TITLE
Add common script to configure public and Insiders builds

### DIFF
--- a/.github/scripts/add-raspap-stage.sh
+++ b/.github/scripts/add-raspap-stage.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -e
+
+mkdir -p stage-raspap/package-raspap
+
+PRERUN_COMMANDS=""
+INSTALLER_COMMANDS=""
+
+if [ -n "$INSIDERS_USER" ] && [ -n "$INSIDERS_TOKEN" ]; then
+  echo ">>> Configuring for private Insiders build."
+
+  PRERUN_COMMANDS=$(
+    cat <<-EOF
+echo "${INSIDERS_TOKEN}" > "\${ROOTFS_DIR}/etc/insiders_token"
+chmod 600 "\${ROOTFS_DIR}/etc/insiders_token"
+EOF
+  )
+
+  INSTALLER_COMMANDS=$(
+    cat <<-EOF
+INSIDERS_TOKEN_VALUE=\$(cat /etc/insiders_token)
+curl -sL https://install.raspap.com | bash -s -- \\
+  --yes --insiders --openvpn 1 --restapi 1 --adblock 1 --wireguard 1 --tcp-bbr 1 --check 0 \\
+  --name "${INSIDERS_USER}" --token "\$INSIDERS_TOKEN_VALUE"
+rm -f /etc/insiders_token
+EOF
+  )
+else
+  echo ">>> Configuring for public build."
+
+  INSTALLER_COMMANDS=$(
+    cat <<-EOF
+curl -sL https://install.raspap.com | bash -s -- --yes --openvpn 1 --restapi 1 --adblock 1 --wireguard 1 --tcp-bbr 1 --check 0
+EOF
+  )
+fi
+
+cat >stage-raspap/prerun.sh <<-EOF
+#!/bin/bash -e
+if [ ! -d "\${ROOTFS_DIR}" ]; then
+  copy_previous
+fi
+${PRERUN_COMMANDS}
+EOF
+
+cat >stage-raspap/package-raspap/00-run-chroot.sh <<-EOF
+#!/bin/bash -e
+apt-get update -y && apt-get install -y curl dhcpcd5 iptables procps
+
+${INSTALLER_COMMANDS}
+
+# Set Wi-Fi country to prevent RF kill
+raspi-config nonint do_wifi_country "US"
+
+# Fetch RaspAP version and set MOTD
+RASPAP_VERSION=\$(curl -sL https://install.raspap.com | bash -s -- --version)
+echo "\$RASPAP_VERSION" | tee /etc/motd
+EOF
+
+chmod +x stage-raspap/prerun.sh
+chmod +x stage-raspap/package-raspap/00-run-chroot.sh
+
+echo "Build configuration complete."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,41 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Add RaspAP Stage
-        run: |
-          mkdir -p stage-raspap/package-raspap &&
-          {
-          cat > stage-raspap/package-raspap/00-run-chroot.sh <<-EOF
-          #!/bin/bash
-          apt-get update -y && apt-get install -y curl dhcpcd5 iptables procps
-          curl -sL https://install.raspap.com | bash -s -- --yes --openvpn 1 --restapi 1 --adblock 1 --wireguard 1 --tcp-bbr 1 --check 0
-
-          # Set Wi-Fi country to prevent RF kill
-          raspi-config nonint do_wifi_country "US"
-
-          # Fetch RaspAP version and set MOTD
-          RASPAP_VERSION=\$(curl -sL https://install.raspap.com | bash -s -- --version)
-          echo "\$RASPAP_VERSION" | tee /etc/motd
-          EOF
-          } &&
-          chmod +x stage-raspap/package-raspap/00-run-chroot.sh &&
-          {
-          cat > stage-raspap/prerun.sh <<-EOF
-          #!/bin/bash -e
-          if [ ! -d "\${ROOTFS_DIR}" ]; then
-            copy_previous
-          fi
-          EOF
-          } &&
-          chmod +x stage-raspap/package-raspap/00-run-chroot.sh &&
-          {
-          cat > stage-raspap/prerun.sh <<-EOF
-          #!/bin/bash -e
-          if [ ! -d "\${ROOTFS_DIR}" ]; then
-            copy_previous
-          fi
-          EOF
-          } &&
-          chmod +x stage-raspap/prerun.sh
+        run: sh ./.github/scripts/add-raspap-stage.sh
 
       - name: Build RaspAP Image
         id: build


### PR DESCRIPTION
/claim #1874

Usage from `RaspAP/raspap-insiders` be like
```sh
wget https://raw.githubusercontent.com/RaspAP/raspap-webgui/refs/heads/master/scripts/add-raspap-stage.sh
INSIDERS_USER="${{ secrets.INSIDERS_USER }}" INSIDERS_TOKEN="${{ secrets.INSIDERS_TOKEN }}" ./add-raspap-stage.sh
```