### PR TITLE
fix: mitigate UUF vulnerability by escaping entity with escapeshellarg

### DIFF
--- a/ajax/networking/get_wgkey.php
+++ b/ajax/networking/get_wgkey.php
@@ -5,7 +5,7 @@ require_once '../../includes/session.php';
 require_once '../../includes/config.php';
 require_once '../../includes/authenticate.php';
 
-$entity = escapeshellcmd($_POST['entity']);
+$entity = escapeshellarg($_POST['entity']);
 
 if (isset($entity)) {
 


### PR DESCRIPTION
## Summary

This PR improves the handling of user-supplied input in `get_wgkey.php`.

### Changes
- Escaped the `entity` parameter using `escapeshellarg()` before passing it into shell commands.
- Ensures safer handling of temporary file generation based on user input.

### Rationale
This change prevents potential misuse of filename parameters.

No functional changes are expected for legitimate users.

---

Please review.