### PR TITLE
Get VPN Provider installation to work on Raspbian

### DIFF
--- a/installers/raspbian.sh
+++ b/installers/raspbian.sh
@@ -106,7 +106,6 @@ function _parse_params() {
     restapi_option=1
     adblock_option=1
     wg_option=1
-    pv_option=0
     insiders=0
     ssh=0
     minwrite=0


### PR DESCRIPTION
Setting `pv_option` to 0 in `_parse_params()` was causing `_install_provider()` from `common.sh` to fail to do its job.