### PR TITLE
API Fixes

### DIFF
--- a/api/modules/ap.py
+++ b/api/modules/ap.py
@@ -35,7 +35,7 @@ def wpa_passphrase():
     return subprocess.run("sed -En 's/wpa_passphrase=(.*)/\1/p' /etc/hostapd/hostapd.conf", shell=True, capture_output=True, text=True).stdout.strip()
 
 def interface():
-    return subprocess.run("cat /etc/hostapd/hostapd.conf | grep interface= | cut -d'=' -f2 | head -1", shell=True, capture_output=True, text=True).stdout.strip()
+    return subprocess.run("cat /etc/hostapd/hostapd.conf | grep '^interface=' | cut -d'=' -f2", shell=True, capture_output=True, text=True).stdout.strip()
 
 def wpa():
     return subprocess.run("cat /etc/hostapd/hostapd.conf | grep wpa= | cut -d'=' -f2", shell=True, capture_output=True, text=True).stdout.strip()

--- a/api/modules/ap.py
+++ b/api/modules/ap.py
@@ -32,7 +32,7 @@ def ieee80211n():
     return subprocess.run("cat /etc/hostapd/hostapd.conf | grep ieee80211n= | cut -d'=' -f2", shell=True, capture_output=True, text=True).stdout.strip()
 
 def wpa_passphrase():
-    return subprocess.run("sed -En 's/wpa_passphrase=(.*)/\1/p' /etc/hostapd/hostapd.conf", shell=True, capture_output=True, text=True).stdout.strip()
+    return subprocess.run("sed -En 's/wpa_passphrase=(.*)/\\1/p' /etc/hostapd/hostapd.conf", shell=True, capture_output=True, text=True).stdout.strip()
 
 def interface():
     return subprocess.run("cat /etc/hostapd/hostapd.conf | grep '^interface=' | cut -d'=' -f2", shell=True, capture_output=True, text=True).stdout.strip()

--- a/api/modules/client.py
+++ b/api/modules/client.py
@@ -3,7 +3,7 @@ import json
 
 def get_active_clients_amount(interface):
     arp_output = subprocess.run(['arp', '-i', interface], capture_output=True, text=True)
-    mac_addresses = arp_output.stdout.splitlines()
+    mac_addresses = mac_addresses = set(line.split()[2] for line in arp_output.stdout.splitlines()[1:])
 
     if mac_addresses:
         grep_pattern = '|'.join(mac_addresses)


### PR DESCRIPTION
The following was noticed as not functioning properly included with the proposed solution.

- `/ap.interface` - Was matching "ctrl_interface" higher in the file. Tweaked the regex to make the line start with "interface" to match the proper line and return the correct value
- `/ap.wpa_passphrase` - escape error that vscode happend to mention when I went to run the command in a JS context
- `/clients/{interface}.active_clients_amount` - The list of arp_addresses was actually an array of lines instead of macs. Just used the same code from the `get_active_clients` function