### PR TITLE
Feature/user interface cleanups

### DIFF
--- a/app/css/all.css
+++ b/app/css/all.css
@@ -122,6 +122,10 @@ th {
   font-size: 0.8rem;
 }
 
+.page-card-header, .modal-title {
+    font-size: 16px;
+}
+
 .dhcp-static-leases {
   margin-top: 1em;
   margin-bottom: 1em;

--- a/app/css/all.css
+++ b/app/css/all.css
@@ -22,6 +22,7 @@ a {
 .sb-sidenav .sb-sidenav-menu .nav .nav-link {
   padding-top: 0.6rem;
   padding-bottom: 0.6rem;
+  font-size: 16px;
 }
 
 .sb-sidenav-light .sb-sidenav-menu .nav-link, .card-title, h4 {

--- a/app/css/all.css
+++ b/app/css/all.css
@@ -298,12 +298,6 @@ button > i.fas {
   border-bottom-right-radius: 0.35rem;
 }
 
-.nav-user {
-  position: relative;
-  bottom: 11px;
-  right: 3px;
-}
-
 .nav-item {
   font-size: 0.85rem;
 }

--- a/app/css/custom.php
+++ b/app/css/custom.php
@@ -105,13 +105,17 @@ a:focus, a:hover {
   background-color: #f2f1f0;
 }
 
-.nav-tabs {
-  flex-wrap: nowrap;
+.nav-tabs-wrapper {
+  width: 100%;
   overflow-x: auto;
-  overflow-y: hidden;
 }
-.nav-tabs::-webkit-scrollbar {
+.nav-tabs-wrapper::-webkit-scrollbar {
   display: none;
+}
+.nav-tabs-wrapper > .nav-tabs {
+  flex-wrap: nowrap;
+  min-width: 100%;
+  width: min-content;
 }
 
 .nav-tabs .nav-link.active,

--- a/app/css/custom.php
+++ b/app/css/custom.php
@@ -75,12 +75,23 @@ a:focus, a:hover {
 }
 
 .btn-primary {
-  color: var(--raspap-theme-color); 
-  border-color: var(--raspap-theme-color); 
-  background-color: #fff;
+  border-color: var(--raspap-theme-color) !important; 
+  background-color: var(--raspap-theme-color) !important;
 }
 
-.btn-primary:disabled {
+.btn-primary.btn-outline {
+  color: var(--raspap-theme-color) !important; 
+  border-color: var(--raspap-theme-color) !important; 
+  background-color: #fff !important;
+}
+
+.btn-primary:hover {
+  color: #fff !important;
+  border-color: var(--raspap-theme-color) !important;
+  background-color: var(--raspap-theme-color) !important; 
+}
+
+.btn-primary.btn-outline:disabled {
   color: var(--raspap-theme-color) !important;
   border-color: var(--raspap-theme-color) !important;
   background-color: #fff !important;
@@ -121,17 +132,8 @@ a.nav-link.active {
   padding: 0.6rem 0.6rem 0.6rem 1.0rem;
 }
 
-.btn-primary {
-  background-color: #fff;
-}
-
 .btn-warning {
   color: #333;
-}
-
-.btn-primary:hover {
-  background-color: var(--raspap-theme-color); 
-  border-color: var(--raspap-theme-color); 
 }
 
 i.fa.fa-bars {

--- a/app/css/custom.php
+++ b/app/css/custom.php
@@ -94,6 +94,15 @@ a:focus, a:hover {
   background-color: #f2f1f0;
 }
 
+.nav-tabs {
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+.nav-tabs::-webkit-scrollbar {
+  display: none;
+}
+
 .nav-tabs .nav-link.active,
 .nav-tabs .nav-link {
   font-size: 1.0rem;
@@ -101,6 +110,7 @@ a:focus, a:hover {
 
 .nav-tabs a.nav-link {
   color: #6e707e;
+  white-space: nowrap;
 }
 
 a.nav-link.active {

--- a/app/js/ajax/main.js
+++ b/app/js/ajax/main.js
@@ -88,12 +88,11 @@ function loadInterfaceDHCPSelect() {
         $('#txtmetric').val(jsonData.Metric);
 
         if (jsonData.StaticIP !== null && jsonData.StaticIP !== '' && !jsonData.FallbackEnabled) {
-            $('#chkstatic').prop('checked', true).closest('.btn').removeClass('btn-outline');
-            $('#chkdhcp').prop('checked', false).closest('.btn').addClass('btn-outline');
+            $('#chkstatic').prop('checked', true).trigger('change');
+            $('#chkdhcp').prop('checked', false).trigger('change');
             $('#chkfallback').prop('disabled', true);
             $('#dhcp-iface').removeAttr('disabled');
         } else {
-            $('#chkdhcp').closest('.btn').removeClass('btn-outline');
             $('#chkdhcp').closest('.btn').blur();
         }
         if (jsonData.FallbackEnabled || $('#chkdhcp').is(':checked')) {

--- a/app/js/ajax/main.js
+++ b/app/js/ajax/main.js
@@ -88,12 +88,12 @@ function loadInterfaceDHCPSelect() {
         $('#txtmetric').val(jsonData.Metric);
 
         if (jsonData.StaticIP !== null && jsonData.StaticIP !== '' && !jsonData.FallbackEnabled) {
-            $('#chkstatic').prop('checked', true).closest('.btn').addClass('active');
-            $('#chkdhcp').prop('checked', false).closest('.btn').removeClass('active');
+            $('#chkstatic').prop('checked', true).closest('.btn').removeClass('btn-outline');
+            $('#chkdhcp').prop('checked', false).closest('.btn').addClass('btn-outline');
             $('#chkfallback').prop('disabled', true);
             $('#dhcp-iface').removeAttr('disabled');
         } else {
-            $('#chkdhcp').closest('.btn').addClass('active');
+            $('#chkdhcp').closest('.btn').removeClass('btn-outline');
             $('#chkdhcp').closest('.btn').blur();
         }
         if (jsonData.FallbackEnabled || $('#chkdhcp').is(':checked')) {

--- a/app/js/ui/main.js
+++ b/app/js/ui/main.js
@@ -582,15 +582,17 @@ $(window).bind("load", function() {
 });
 
 // Sets focus on a specified tab
-document.addEventListener("DOMContentLoaded", function () {
-    const params = new URLSearchParams(window.location.search);
-    const targetTab = params.get("tab");
-    if (targetTab) {
-        let tabElement = document.querySelector(`[data-bs-toggle="tab"][href="#${targetTab}"]`);
-        if (tabElement) {
-            let tab = new bootstrap.Tab(tabElement);
-            tab.show();
-        }
+jQuery(function() {
+    // Store hash in URL
+    $('a[data-bs-toggle="tab"]').on('shown.bs.tab', function (e) {
+        var hash = $(e.target).attr('href');
+        history.pushState(null, null, hash);
+    });
+
+    // Activate tab based on URL hash
+    var hash = window.location.hash;
+    if (hash) {
+        $('.nav-link[href="' + hash + '"]').tab('show');
     }
 });
 

--- a/app/js/ui/main.js
+++ b/app/js/ui/main.js
@@ -185,6 +185,14 @@ function contentLoaded() {
 }
 
 function setDHCPToggles(state) {
+    if (state) {
+        $('#chkdhcp').closest('.btn').addClass('btn-outline');
+        $('#chkstatic').closest('.btn').removeClass('btn-outline');
+    } else {
+        $('#chkdhcp').closest('.btn').removeClass('btn-outline');
+        $('#chkstatic').closest('.btn').addClass('btn-outline');
+    }
+
     if ($('#chkfallback').is(':checked') && state) {
         $('#chkfallback').prop('checked', state);
     }

--- a/app/js/ui/main.js
+++ b/app/js/ui/main.js
@@ -185,14 +185,6 @@ function contentLoaded() {
 }
 
 function setDHCPToggles(state) {
-    if (state) {
-        $('#chkdhcp').closest('.btn').addClass('btn-outline');
-        $('#chkstatic').closest('.btn').removeClass('btn-outline');
-    } else {
-        $('#chkdhcp').closest('.btn').removeClass('btn-outline');
-        $('#chkstatic').closest('.btn').addClass('btn-outline');
-    }
-
     if ($('#chkfallback').is(':checked') && state) {
         $('#chkfallback').prop('checked', state);
     }
@@ -397,12 +389,24 @@ $(document).ready(function () {
 // DHCP or Static IP option group
 $('#chkstatic').on('change', function() {
     if (this.checked) {
+        $('#chkstatic').closest('.btn').removeClass('btn-outline');
+        $('#chkdhcp').closest('.btn').addClass('btn-outline');
         setStaticFieldsEnabled();
+    } else {
+        $('#chkstatic').closest('.btn').addClass('btn-outline');
+        $('#chkdhcp').closest('.btn').removeClass('btn-outline');
     }
 });
 
 $('#chkdhcp').on('change', function() {
-    this.checked ? setStaticFieldsDisabled() : null;
+    if (this.checked) {
+        $('#chkdhcp').closest('.btn').removeClass('btn-outline');
+        $('#chkstatic').closest('.btn').addClass('btn-outline');
+        setStaticFieldsDisabled();
+    } else {
+        $('#chkdhcp').closest('.btn').addClass('btn-outline');
+        $('#chkstatic').closest('.btn').removeClass('btn-outline');
+    }
 });
 
 

--- a/includes/dhcp.php
+++ b/includes/dhcp.php
@@ -64,6 +64,7 @@ function DisplayDHCPConfig()
         }
     }
     $ap_iface = $_SESSION['ap_interface'];
+    $initial_iface = isset($_POST['interface']) ? $_POST['interface'] : $ap_iface;
     $serviceStatus = $dnsmasq_state ? "up" : "down";
     exec('cat '. RASPI_DNSMASQ_PREFIX.'raspap.conf', $return);
     $log_dhcp = (preg_grep('/log-dhcp/', $return));
@@ -87,7 +88,7 @@ function DisplayDHCPConfig()
             "status",
             "serviceStatus",
             "dnsmasq_state",
-            "ap_iface",
+            "initial_iface",
             "conf",
             "hosts",
             "upstreamServers",

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -1,6 +1,6 @@
 <?php $_SESSION['lastActivity'] = time(); ?>
 
-<div class="d-flex align-items-center justify-content-between small">
+<div class="d-flex flex-column flex-sm-row align-items-center justify-content-between small">
   <div class="text-muted">
     <span class="pe-2"><a href="/about">v<?php echo RASPI_VERSION; ?></a></span>  |
     <span class="ps-2"><?php echo sprintf(_('Created by the <a href="%s" target="_blank" rel="noopener">%s</a>'), 'https://github.com/RaspAP', _('RaspAP Team')); ?></span>

--- a/includes/navbar.php
+++ b/includes/navbar.php
@@ -1,20 +1,24 @@
-  <nav class="sb-topnav navbar navbar-expand navbar-light bg-light">
+<nav class="sb-topnav navbar navbar-expand navbar-light bg-light">
   <!-- Navbar Brand-->
-  <a class="sidebar-brand-text navbar-brand ps-5" href="wlan0_info">RaspAP</a>
+  <a class="sidebar-brand-text navbar-brand ps-3" href="wlan0_info">RaspAP</a>
   <!-- Sidebar Toggle-->
-  <button class="btn btn-link btn-sm order-1 order-lg-0 me-auto p-3 bd-highlight" id="sidebarToggle" href="#!"><i class="fas fa-bars"></i></button>
+  <button class="btn btn-link btn-lg order-1 order-lg-0 me-lg-auto py-2 px-3 bd-highlight" id="sidebarToggle" href="#!">
+    <i class="fas fa-bars"></i>
+  </button>
   <!-- Navbar-->
-  <ul class="navbar-nav ms-auto ms-md-0 me-2 me-lg-4">
+  <ul class="navbar-nav align-items-center gap-3 ms-auto ms-lg-0 me-2 me-lg-4">
     <!-- Display mode -->
-    <div class="form-check form-switch p-4 mt-1">
-      <input type="checkbox" class="form-check-input" id="night-mode" <?php echo getNightmode() ? 'checked' : null ; ?> >
-      <label class="form-check-label" for="night-mode"><i class="far fa-moon mr-1 text-muted"></i></label>
-    </div>
+    <li>
+      <div class="form-check form-switch pl-6 mb-0" style="min-height: initial;">
+        <input type="checkbox" class="form-check-input" id="night-mode" <?php echo getNightmode() ? 'checked' : null ; ?> >
+        <label class="form-check-label" for="night-mode"><i class="far fa-moon mr-1 text-muted"></i></label>
+      </div>
+    </li>
     <!-- Auth user -->
-    <li class="nav-item mt-1">
-      <a class="nav-link" href="auth_conf">
-        <span class="mr-2 small nav-user"><?php echo htmlspecialchars($_SESSION['user_id'] ?? '', ENT_QUOTES); ?></span>
-        <i class="fas fa-user-circle text-muted mt-2 fa-3x"></i>
+    <li>
+      <a class="d-flex flex-nowrap align-items-center gap-1" href="auth_conf">
+        <span class="text-muted small"><?php echo htmlspecialchars($_SESSION['user_id'] ?? '', ENT_QUOTES); ?></span>
+        <i class="fas fa-user-circle text-muted fa-3x"></i>
       </a>
     </li>
   </ul>

--- a/templates/about.php
+++ b/templates/about.php
@@ -6,7 +6,7 @@ require_once 'app/lib/Parsedown.php';
 <div class="row">
   <div class="col-lg-12">
     <div class="card">
-      <div class="card-header">
+      <div class="card-header page-card-header">
         <div class="row">
           <div class="col">
             <i class="fas fa-info-circle me-2"></i><?php echo _("About RaspAP"); ?>

--- a/templates/about.php
+++ b/templates/about.php
@@ -16,11 +16,13 @@ require_once 'app/lib/Parsedown.php';
       <div class="card-body">
 
         <!-- Nav tabs -->
-        <ul class="nav nav-tabs">
-          <li class="nav-item"><a class="nav-link active" href="#aboutgeneral" data-bs-toggle="tab"><?php echo _("About"); ?></a></li>
-          <li class="nav-item"><a class="nav-link" href="#aboutsponsors" data-bs-toggle="tab"><?php echo _("Insiders"); ?></a></li>
-          <li class="nav-item"><a class="nav-link" href="#aboutcontrib" data-bs-toggle="tab"><?php echo _("Contributing"); ?></a></li>
-        </ul>
+        <div class="nav-tabs-wrapper">
+          <ul class="nav nav-tabs">
+            <li class="nav-item"><a class="nav-link active" href="#aboutgeneral" data-bs-toggle="tab"><?php echo _("About"); ?></a></li>
+            <li class="nav-item"><a class="nav-link" href="#aboutsponsors" data-bs-toggle="tab"><?php echo _("Insiders"); ?></a></li>
+            <li class="nav-item"><a class="nav-link" href="#aboutcontrib" data-bs-toggle="tab"><?php echo _("Contributing"); ?></a></li>
+          </ul>
+        </div>
         <!-- /.nav-tabs -->
 
         <!-- Tab panes -->

--- a/templates/adblock.php
+++ b/templates/adblock.php
@@ -12,7 +12,7 @@
   <div class="row">
     <div class="col-lg-12">
       <div class="card">
-        <div class="card-header">
+        <div class="card-header page-card-header">
           <div class="row align-items-center">
             <div class="col">
               <i class="far fa-hand-paper me-2"></i><?php echo _("Ad Blocking"); ?>

--- a/templates/adblock.php
+++ b/templates/adblock.php
@@ -30,11 +30,13 @@
           <form role="form" action="adblock_conf" enctype="multipart/form-data" method="POST">
             <?php echo \RaspAP\Tokens\CSRF::hiddenField();?>
             <!-- Nav tabs -->
-            <ul class="nav nav-tabs">
-                <li class="nav-item"><a class="nav-link active" id="blocklisttab" href="#adblocklistsettings" data-bs-toggle="tab"><?php echo _("Blocklist settings"); ?></a></li>
-                <li class="nav-item"><a class="nav-link" id="customtab" href="#adblockcustom" data-bs-toggle="tab"><?php echo _("Custom blocklist"); ?></a></li>
-                <li class="nav-item"><a class="nav-link" id="logoutputtab" href="#adblocklogfileoutput" data-bs-toggle="tab"><?php echo _("Logging"); ?></a></li>
-            </ul>
+            <div class="nav-tabs-wrapper">
+              <ul class="nav nav-tabs">
+                  <li class="nav-item"><a class="nav-link active" id="blocklisttab" href="#adblocklistsettings" data-bs-toggle="tab"><?php echo _("Blocklist settings"); ?></a></li>
+                  <li class="nav-item"><a class="nav-link" id="customtab" href="#adblockcustom" data-bs-toggle="tab"><?php echo _("Custom blocklist"); ?></a></li>
+                  <li class="nav-item"><a class="nav-link" id="logoutputtab" href="#adblocklogfileoutput" data-bs-toggle="tab"><?php echo _("Logging"); ?></a></li>
+              </ul>
+            </div>
 
             <!-- Tab panes -->
             <div class="tab-content">

--- a/templates/adblock.php
+++ b/templates/adblock.php
@@ -13,7 +13,7 @@
     <div class="col-lg-12">
       <div class="card">
         <div class="card-header">
-          <div class="row">
+          <div class="row align-items-center">
             <div class="col">
               <i class="far fa-hand-paper me-2"></i><?php echo _("Ad Blocking"); ?>
             </div>
@@ -44,7 +44,9 @@
               <?php echo renderTemplate("adblock/logging", $__template_data) ?>
             </div><!-- /.tab-content -->
 
-          <?php echo $buttons ?>
+            <div class="d-flex flex-wrap gap-2">
+              <?php echo $buttons ?>
+            </div>
           </form>
         </div><!-- /.card-body -->
         <div class="card-footer"><?php echo _("Information provided by adblock"); ?></div>

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -8,7 +8,7 @@
 <div class="row">
   <div class="col-lg-12">
     <div class="card">
-      <div class="card-header">
+      <div class="card-header page-card-header">
         <div class="row">
 	      <div class="col">
             <i class="fas fa-user-lock me-2"></i><?php echo _("Authentication"); ?>

--- a/templates/configure_client.php
+++ b/templates/configure_client.php
@@ -1,7 +1,7 @@
 <div class="row" id="wifiClientContent">
   <div class="col-lg-12">
     <div class="card">
-      <div class="card-header">
+      <div class="card-header page-card-header">
         <div class="row align-items-center">
           <div class="col">
             <i class="fas fa-wifi me-2"></i><?php echo _("WiFi client"); ?>

--- a/templates/dashboard.php
+++ b/templates/dashboard.php
@@ -33,10 +33,12 @@
           <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
 
           <!-- Nav tabs -->
-          <ul class="nav nav-tabs">
-            <li class="nav-item"><a class="nav-link active" id="statustab" href="#status" aria-controls="status" data-bs-toggle="tab"><?php echo _("Status"); ?></a></li>
-            <li class="nav-item"><a class="nav-link" id="datatab" href="#data" data-bs-toggle="tab"><?php echo _("Data usage"); ?></a></li>
-          </ul>
+          <div class="nav-tabs-wrapper">
+            <ul class="nav nav-tabs">
+              <li class="nav-item"><a class="nav-link active" id="statustab" href="#status" aria-controls="status" data-bs-toggle="tab"><?php echo _("Status"); ?></a></li>
+              <li class="nav-item"><a class="nav-link" id="datatab" href="#data" data-bs-toggle="tab"><?php echo _("Data usage"); ?></a></li>
+            </ul>
+          </div>
 
           <!-- Tab panes -->
           <div class="tab-content">

--- a/templates/dashboard.php
+++ b/templates/dashboard.php
@@ -12,7 +12,7 @@
 <div class="row">
   <div class="col-lg-12">
     <div class="card">
-      <div class="card-header">
+      <div class="card-header page-card-header">
         <div class="row align-items-center">
           <div class="col">
             <i class="fas fa-tachometer-alt fa-fw me-2"></i>

--- a/templates/dashboard.php
+++ b/templates/dashboard.php
@@ -13,7 +13,7 @@
   <div class="col-lg-12">
     <div class="card">
       <div class="card-header">
-        <div class="row">
+        <div class="row align-items-center">
           <div class="col">
             <i class="fas fa-tachometer-alt fa-fw me-2"></i>
             <?php echo _("Dashboard"); ?>
@@ -44,7 +44,9 @@
             <?php echo renderTemplate("dashboard/data", $__template_data) ?>
           </div><!-- /.tab-content -->
 
-          <?php echo $buttons ?>
+          <div class="d-flex flex-wrap gap-2">
+            <?php echo $buttons ?>
+          </div>
         </form>
       </div><!-- /.card-body -->
 

--- a/templates/data_usage.php
+++ b/templates/data_usage.php
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-lg-12">
     <div class="card">
-      <div class="card-header">
+      <div class="card-header page-card-header">
         <div class="row">
           <div class="col">
             <i class="fas fa-chart-area me-2"></i><?php echo _("Data usage monitoring"); ?>

--- a/templates/data_usage.php
+++ b/templates/data_usage.php
@@ -9,11 +9,13 @@
         </div><!-- /.row -->
       </div><!-- /.card-header -->
 			<div class="card-body">
-				<ul id="tabbarBandwidth" class="nav nav-tabs" role="tablist">
-					<li class="nav-item"><a class="nav-link active" href="#hourly" aria-controls="hourly" role="tab" data-bs-toggle="tab"><?php echo _("Hourly"); ?></a></li>
-					<li class="nav-item"><a class="nav-link" href="#daily" aria-controls="daily" role="tab" data-bs-toggle="tab"><?php echo _("Daily"); ?></a></li>
-					<li class="nav-item"><a class="nav-link" href="#monthly" aria-controls="monthly" role="tab" data-bs-toggle="tab"><?php echo _("Monthly"); ?></a></li>
-				</ul>
+				<div class="nav-tabs-wrapper">
+					<ul id="tabbarBandwidth" class="nav nav-tabs" role="tablist">
+						<li class="nav-item"><a class="nav-link active" href="#hourly" aria-controls="hourly" role="tab" data-bs-toggle="tab"><?php echo _("Hourly"); ?></a></li>
+						<li class="nav-item"><a class="nav-link" href="#daily" aria-controls="daily" role="tab" data-bs-toggle="tab"><?php echo _("Daily"); ?></a></li>
+						<li class="nav-item"><a class="nav-link" href="#monthly" aria-controls="monthly" role="tab" data-bs-toggle="tab"><?php echo _("Monthly"); ?></a></li>
+					</ul>
+				</div>
 				<div id="tabsBandwidth" class="tabcontenttraffic tab-content">
 					<div role="tabpanel" class="tab-pane active" id="hourly">
 						<div class="row">

--- a/templates/dhcp.php
+++ b/templates/dhcp.php
@@ -34,13 +34,15 @@
           <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
 
           <!-- Nav tabs -->
-          <ul class="nav nav-tabs mb-3">
-            <li class="nav-item"><a class="nav-link active" href="#server-settings" data-bs-toggle="tab"><?php echo _("Server settings"); ?></a></li>
-            <li class="nav-item"><a class="nav-link" href="#advanced" data-bs-toggle="tab"><?php echo _("Advanced"); ?></a></li>
-            <li class="nav-item"><a class="nav-link" href="#static-leases" data-bs-toggle="tab"><?php echo _("Static Leases") ?></a></li>
-            <li class="nav-item"><a class="nav-link" href="#client-list" data-bs-toggle="tab"><?php echo _("Client list"); ?></a></li>
-            <li class="nav-item"><a class="nav-link" href="#logging" data-bs-toggle="tab"><?php echo _("Logging"); ?></a></li>
-          </ul>
+          <div class="nav-tabs-wrapper">
+            <ul class="nav nav-tabs mb-3">
+              <li class="nav-item"><a class="nav-link active" href="#server-settings" data-bs-toggle="tab"><?php echo _("Server settings"); ?></a></li>
+              <li class="nav-item"><a class="nav-link" href="#advanced" data-bs-toggle="tab"><?php echo _("Advanced"); ?></a></li>
+              <li class="nav-item"><a class="nav-link" href="#static-leases" data-bs-toggle="tab"><?php echo _("Static Leases") ?></a></li>
+              <li class="nav-item"><a class="nav-link" href="#client-list" data-bs-toggle="tab"><?php echo _("Client list"); ?></a></li>
+              <li class="nav-item"><a class="nav-link" href="#logging" data-bs-toggle="tab"><?php echo _("Logging"); ?></a></li>
+            </ul>
+          </div>
 
           <!-- Tab panes -->
           <div class="tab-content">

--- a/templates/dhcp.php
+++ b/templates/dhcp.php
@@ -15,7 +15,7 @@
     <div class="card">
 
       <div class="card-header">
-        <div class="row">
+        <div class="row align-items-center">
           <div class="col">
             <i class="fas fa-exchange-alt me-2"></i><?php echo _("DHCP Server"); ?>
           </div>
@@ -51,7 +51,9 @@
             <?php echo renderTemplate("dhcp/logging", $__template_data) ?>
           </div><!-- /.tab-content -->
 
-          <?php echo $buttons ?>
+          <div class="d-flex flex-wrap gap-2">
+            <?php echo $buttons ?>
+          </div>
         </form>
       </div><!-- ./ card-body -->
 

--- a/templates/dhcp.php
+++ b/templates/dhcp.php
@@ -14,7 +14,7 @@
   <div class="col-lg-12">
     <div class="card">
 
-      <div class="card-header">
+      <div class="card-header page-card-header">
         <div class="row align-items-center">
           <div class="col">
             <i class="fas fa-exchange-alt me-2"></i><?php echo _("DHCP Server"); ?>

--- a/templates/dhcp/general.php
+++ b/templates/dhcp/general.php
@@ -3,7 +3,7 @@
   <div class="row">
     <div class="mb-3 col-md-6">
       <label for="code"><?php echo _("Interface"); ?></label>
-        <?php SelectorOptions('interface', $interfaces, $ap_iface, 'cbxdhcpiface', 'loadInterfaceDHCPSelect'); ?>
+        <?php SelectorOptions('interface', $interfaces, $initial_iface, 'cbxdhcpiface', 'loadInterfaceDHCPSelect'); ?>
     </div>
   </div>
 

--- a/templates/dhcp/general.php
+++ b/templates/dhcp/general.php
@@ -11,11 +11,11 @@
   <div class="row">
     <div class="mb-3 col-md-6">
       <div class="btn-group" role="group" data-bs-toggle="buttons">
-        <label class="btn btn-light active" checked onclick="setDHCPToggles(false)">
-          <input type="radio" name="adapter-ip" id="chkdhcp" autocomplete="off"> DHCP
+        <label class="btn btn-primary btn-outline" onclick="setDHCPToggles(false)">
+          <input type="radio" name="adapter-ip" id="chkdhcp" autocomplete="off" class="d-none"> DHCP
         </label>
-        <label class="btn btn-light" onclick="setDHCPToggles(true)">
-          <input type="radio" name="adapter-ip" id="chkstatic" autocomplete="off"> Static IP
+        <label class="btn btn-primary btn-outline" onclick="setDHCPToggles(true)">
+          <input type="radio" name="adapter-ip" id="chkstatic" autocomplete="off" class="d-none"> Static IP
         </label>
       </div>
     </div>

--- a/templates/hostapd.php
+++ b/templates/hostapd.php
@@ -53,12 +53,14 @@
           <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
 
           <!-- Nav tabs -->
-          <ul class="nav nav-tabs">
-            <li class="nav-item"><a class="nav-link active" id="basictab" href="#basic" aria-controls="basic" data-bs-toggle="tab"><?php echo _("Basic"); ?></a></li>
-            <li class="nav-item"><a class="nav-link" id="securitytab" href="#security" data-bs-toggle="tab"><?php echo _("Security"); ?></a></li>
-            <li class="nav-item"><a class="nav-link" id="advancedtab" href="#advanced" data-bs-toggle="tab"><?php echo _("Advanced"); ?></a></li>
-            <li class="nav-item"><a class="nav-link" id="logoutputtab" href="#logoutput" data-bs-toggle="tab"><?php echo _("Logging"); ?></a></li>
-          </ul>
+          <div class="nav-tabs-wrapper">
+            <ul class="nav nav-tabs">
+              <li class="nav-item"><a class="nav-link active" id="basictab" href="#basic" aria-controls="basic" data-bs-toggle="tab"><?php echo _("Basic"); ?></a></li>
+              <li class="nav-item"><a class="nav-link" id="securitytab" href="#security" data-bs-toggle="tab"><?php echo _("Security"); ?></a></li>
+              <li class="nav-item"><a class="nav-link" id="advancedtab" href="#advanced" data-bs-toggle="tab"><?php echo _("Advanced"); ?></a></li>
+              <li class="nav-item"><a class="nav-link" id="logoutputtab" href="#logoutput" data-bs-toggle="tab"><?php echo _("Logging"); ?></a></li>
+            </ul>
+          </div>
 
           <!-- Tab panes -->
           <div class="tab-content">

--- a/templates/hostapd.php
+++ b/templates/hostapd.php
@@ -33,7 +33,7 @@
   <div class="col-lg-12">
     <div class="card">
 
-      <div class="card-header">
+      <div class="card-header page-card-header">
         <div class="row align-items-center">
           <div class="col">
             <i class="fas fa-bullseye me-2"></i><?php echo _("Hotspot"); ?>

--- a/templates/hostapd.php
+++ b/templates/hostapd.php
@@ -34,7 +34,7 @@
     <div class="card">
 
       <div class="card-header">
-        <div class="row">
+        <div class="row align-items-center">
           <div class="col">
             <i class="fas fa-bullseye me-2"></i><?php echo _("Hotspot"); ?>
           </div>
@@ -68,7 +68,9 @@
             <?php echo renderTemplate("hostapd/logging", $__template_data) ?>
           </div><!-- /.tab-content -->
 
-          <?php echo $buttons ?>
+          <div class="d-flex flex-wrap gap-2">
+            <?php echo $buttons ?>
+          </div>
         </form>
       </div><!-- /.card-body -->
 

--- a/templates/networking.php
+++ b/templates/networking.php
@@ -2,7 +2,7 @@
 <div class="row">
   <div class="col-lg-12">
     <div class="card">
-      <div class="card-header">
+      <div class="card-header page-card-header">
         <div class="row">
           <div class="col">
             <i class="fas fa-network-wired me-2"></i><?php echo _("Networking"); ?>

--- a/templates/networking.php
+++ b/templates/networking.php
@@ -15,12 +15,14 @@
         <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
         <div id="msgNetworking"></div>
         <!-- Nav tabs -->
-        <ul class="nav nav-tabs">
-          <li class="nav-item"><a class="nav-link active" href="#summary" aria-controls="summary" role="tab" data-bs-toggle="tab"><?php echo _("Summary"); ?></a></li>
-          <?php if (!$bridgedEnabled) : // no interface details when bridged ?>
-            <li class="nav-item"><a class="nav-link" href="#diagnostic" aria-controls="diagnostic" role="tab" data-bs-toggle="tab"><?php echo _("Diagnostics"); ?></a></li>
-          <?php endif ?>
-        </ul>
+        <div class="nav-tabs-wrapper">
+          <ul class="nav nav-tabs">
+            <li class="nav-item"><a class="nav-link active" href="#summary" aria-controls="summary" role="tab" data-bs-toggle="tab"><?php echo _("Summary"); ?></a></li>
+            <?php if (!$bridgedEnabled) : // no interface details when bridged ?>
+              <li class="nav-item"><a class="nav-link" href="#diagnostic" aria-controls="diagnostic" role="tab" data-bs-toggle="tab"><?php echo _("Diagnostics"); ?></a></li>
+            <?php endif ?>
+          </ul>
+        </div>
 
         <!-- Tab panes -->
         <div class="tab-content">

--- a/templates/openvpn.php
+++ b/templates/openvpn.php
@@ -14,7 +14,7 @@
   <div class="row">
     <div class="col-lg-12">
       <div class="card">
-        <div class="card-header">
+        <div class="card-header page-card-header">
           <div class="row align-items-center">
             <div class="col">
               <i class="fas fa-key fa-fw me-2"></i><?php echo _("OpenVPN"); ?>

--- a/templates/openvpn.php
+++ b/templates/openvpn.php
@@ -32,11 +32,13 @@
           <form role="form" action="openvpn_conf" enctype="multipart/form-data" method="POST">
             <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
             <!-- Nav tabs -->
-            <ul class="nav nav-tabs">
-                <li class="nav-item"><a class="nav-link active" id="clienttab" href="#openvpnclient" data-bs-toggle="tab"><?php echo _("Client settings"); ?></a></li>
-                <li class="nav-item"><a class="nav-link" id="configstab" href="#openvpnconfigs" data-bs-toggle="tab"><?php echo _("Configurations"); ?></a></li>
-                <li class="nav-item"><a class="nav-link" id="loggingtab" href="#openvpnlogging" data-bs-toggle="tab"><?php echo _("Logging"); ?></a></li>
-            </ul>
+            <div class="nav-tabs-wrapper">
+              <ul class="nav nav-tabs">
+                  <li class="nav-item"><a class="nav-link active" id="clienttab" href="#openvpnclient" data-bs-toggle="tab"><?php echo _("Client settings"); ?></a></li>
+                  <li class="nav-item"><a class="nav-link" id="configstab" href="#openvpnconfigs" data-bs-toggle="tab"><?php echo _("Configurations"); ?></a></li>
+                  <li class="nav-item"><a class="nav-link" id="loggingtab" href="#openvpnlogging" data-bs-toggle="tab"><?php echo _("Logging"); ?></a></li>
+              </ul>
+            </div>
 
             <!-- Tab panes -->
             <div class="tab-content">

--- a/templates/openvpn.php
+++ b/templates/openvpn.php
@@ -15,7 +15,7 @@
     <div class="col-lg-12">
       <div class="card">
         <div class="card-header">
-          <div class="row">
+          <div class="row align-items-center">
             <div class="col">
               <i class="fas fa-key fa-fw me-2"></i><?php echo _("OpenVPN"); ?>
             </div>
@@ -45,7 +45,9 @@
               <?php echo renderTemplate("openvpn/logging", $__template_data) ?>
             </div><!-- /.tab-content -->
 
-            <?php echo $buttons ?>
+            <div class="d-flex flex-wrap gap-2">
+              <?php echo $buttons ?>
+            </div>
           </form>
         </div><!-- /.card-body -->
       <div class="card-footer"><?php echo _("Information provided by openvpn"); ?></div>

--- a/templates/provider.php
+++ b/templates/provider.php
@@ -13,7 +13,7 @@
     <div class="col-lg-12">
       <div class="card">
         <div class="card-header">
-          <div class="row">
+          <div class="row align-items-center">
             <div class="col">
               <i class="fas fa-shield-alt fa-fw me-2"></i><?php echo _($providerName); ?>
             </div>
@@ -41,7 +41,9 @@
               <?php echo renderTemplate("provider/status", $__template_data) ?>
             </div><!-- /.tab-content -->
 
-            <?php echo $buttons ?>
+            <div class="d-flex flex-wrap gap-2">
+              <?php echo $buttons ?>
+            </div>
           </form>
         </div><!-- /.card-body -->
       <div class="card-footer"><?php echo sprintf( _("Information provided by %s"), strtolower($providerName)); ?></div>

--- a/templates/provider.php
+++ b/templates/provider.php
@@ -30,10 +30,12 @@
           <form role="form" action="provider_conf" enctype="multipart/form-data" method="POST">
             <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
             <!-- Nav tabs -->
-            <ul class="nav nav-tabs">
-                <li class="nav-item"><a class="nav-link active" id="clienttab" href="#providerclient" data-bs-toggle="tab"><?php echo _("Settings"); ?></a></li>
-                <li class="nav-item"><a class="nav-link" id="loggingtab" href="#providerstatus" data-bs-toggle="tab"><?php echo _("Status"); ?></a></li>
-            </ul>
+            <div class="nav-tabs-wrapper">
+              <ul class="nav nav-tabs">
+                  <li class="nav-item"><a class="nav-link active" id="clienttab" href="#providerclient" data-bs-toggle="tab"><?php echo _("Settings"); ?></a></li>
+                  <li class="nav-item"><a class="nav-link" id="loggingtab" href="#providerstatus" data-bs-toggle="tab"><?php echo _("Status"); ?></a></li>
+              </ul>
+            </div>
 
             <!-- Tab panes -->
             <div class="tab-content">

--- a/templates/provider.php
+++ b/templates/provider.php
@@ -12,7 +12,7 @@
   <div class="row">
     <div class="col-lg-12">
       <div class="card">
-        <div class="card-header">
+        <div class="card-header page-card-header">
           <div class="row align-items-center">
             <div class="col">
               <i class="fas fa-shield-alt fa-fw me-2"></i><?php echo _($providerName); ?>

--- a/templates/restapi.php
+++ b/templates/restapi.php
@@ -30,10 +30,12 @@
           <form role="form" action="restapi_conf" method="POST" class="needs-validation" novalidate>
             <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
             <!-- Nav tabs -->
-            <ul class="nav nav-tabs">
-                <li class="nav-item"><a class="nav-link active" id="restapisettingstab" href="#restapisettings" data-bs-toggle="tab"><?php echo _("Settings"); ?></a></li>
-                <li class="nav-item"><a class="nav-link" id="restapistatustab" href="#restapistatus" data-bs-toggle="tab"><?php echo _("Status"); ?></a></li>
-            </ul>
+            <div class="nav-tabs-wrapper">
+              <ul class="nav nav-tabs">
+                  <li class="nav-item"><a class="nav-link active" id="restapisettingstab" href="#restapisettings" data-bs-toggle="tab"><?php echo _("Settings"); ?></a></li>
+                  <li class="nav-item"><a class="nav-link" id="restapistatustab" href="#restapistatus" data-bs-toggle="tab"><?php echo _("Status"); ?></a></li>
+              </ul>
+            </div>
 
             <!-- Tab panes -->
             <div class="tab-content">

--- a/templates/restapi.php
+++ b/templates/restapi.php
@@ -12,7 +12,7 @@
   <div class="row">
     <div class="col-lg-12">
       <div class="card">
-        <div class="card-header">
+        <div class="card-header page-card-header">
           <div class="row align-items-center">
             <div class="col">
               <i class="fas fa-puzzle-piece me-2"></i><?php echo _("RestAPI"); ?>

--- a/templates/restapi.php
+++ b/templates/restapi.php
@@ -13,7 +13,7 @@
     <div class="col-lg-12">
       <div class="card">
         <div class="card-header">
-          <div class="row">
+          <div class="row align-items-center">
             <div class="col">
               <i class="fas fa-puzzle-piece me-2"></i><?php echo _("RestAPI"); ?>
             </div>
@@ -41,7 +41,9 @@
               <?php echo renderTemplate("restapi/status", $__template_data) ?>
             </div><!-- /.tab-content -->
 
-            <?php echo $buttons ?>
+            <div class="d-flex flex-wrap gap-2">
+              <?php echo $buttons ?>
+            </div>
           </form>
         </div><!-- /.card-body -->
       <div class="card-footer"><?php echo _("Information provided by restapi.service"); ?></div>

--- a/templates/system.php
+++ b/templates/system.php
@@ -12,16 +12,18 @@
         <?php $status->showMessages(); ?>
         <form role="form" action="system_info" method="POST">
         <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
-        <ul class="nav nav-tabs" role="tablist">
-          <li role="presentation" class="nav-item"><a class="nav-link active" id="basictab" href="#basic" aria-controls="basic" role="tab" data-bs-toggle="tab"><?php echo _("Basic"); ?></a></li>
-          <li role="presentation" class="nav-item"><a class="nav-link" id="languagetab" href="#language" aria-controls="language" role="tab" data-bs-toggle="tab"><?php echo _("Language"); ?></a></li>
-          <li role="presentation" class="nav-item"><a class="nav-link" id="themetab" href="#theme" aria-controls="theme" role="tab" data-bs-toggle="tab"><?php echo _("Theme"); ?></a></li>
-          <li role="presentation" class="nav-item"><a class="nav-link" id="advancedtab" href="#advanced" aria-controls="advanced" role="tab" data-bs-toggle="tab"><?php echo _("Advanced"); ?></a></li>
-          <li role="presentation" class="nav-item"><a class="nav-link" id="toolstab" href="#tools" aria-controls="tools" role="tab" data-bs-toggle="tab"><?php echo _("Tools"); ?></a></li>
-          <?php if (RASPI_PLUGINS_ENABLED) : ?>
-          <li role="presentation" class="nav-item"><a class="nav-link" id="pluginstab" href="#plugins" aria-controls="plugins" role="tab" data-bs-toggle="tab"><?php echo _("Plugins"); ?></a></li>
-          <?php endif ?>
-        </ul>
+        <div class="nav-tabs-wrapper">
+          <ul class="nav nav-tabs" role="tablist">
+            <li role="presentation" class="nav-item"><a class="nav-link active" id="basictab" href="#basic" aria-controls="basic" role="tab" data-bs-toggle="tab"><?php echo _("Basic"); ?></a></li>
+            <li role="presentation" class="nav-item"><a class="nav-link" id="languagetab" href="#language" aria-controls="language" role="tab" data-bs-toggle="tab"><?php echo _("Language"); ?></a></li>
+            <li role="presentation" class="nav-item"><a class="nav-link" id="themetab" href="#theme" aria-controls="theme" role="tab" data-bs-toggle="tab"><?php echo _("Theme"); ?></a></li>
+            <li role="presentation" class="nav-item"><a class="nav-link" id="advancedtab" href="#advanced" aria-controls="advanced" role="tab" data-bs-toggle="tab"><?php echo _("Advanced"); ?></a></li>
+            <li role="presentation" class="nav-item"><a class="nav-link" id="toolstab" href="#tools" aria-controls="tools" role="tab" data-bs-toggle="tab"><?php echo _("Tools"); ?></a></li>
+            <?php if (RASPI_PLUGINS_ENABLED) : ?>
+            <li role="presentation" class="nav-item"><a class="nav-link" id="pluginstab" href="#plugins" aria-controls="plugins" role="tab" data-bs-toggle="tab"><?php echo _("Plugins"); ?></a></li>
+            <?php endif ?>
+          </ul>
+        </div>
           <!-- Tab panes -->
           <div class="tab-content">
             <?php echo renderTemplate("system/basic", $__template_data) ?>

--- a/templates/system.php
+++ b/templates/system.php
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-lg-12">
     <div class="card">
-      <div class="card-header">
+      <div class="card-header page-card-header">
         <div class="row">
           <div class="col">
             <i class="fas fa-cube me-2"></i><?php echo _("System"); ?>

--- a/templates/system/advanced.php
+++ b/templates/system/advanced.php
@@ -1,30 +1,32 @@
 <!-- advanced tab -->
 <div role="tabpanel" class="tab-pane" id="advanced">
   <h4 class="mt-3"><?php echo _("Advanced settings") ;?></h4>
-    <?php if (!RASPI_MONITOR_ENABLED) : ?>
-    <form action="system_info" method="POST">
-    <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
-      <div class="row">
-        <div class="mb-3 col-md-6">
-          <label for="code"><?php echo _("Web server port") ;?></label>
-          <input type="text" class="form-control" name="serverPort" value="<?php echo htmlspecialchars($serverPort, ENT_QUOTES); ?>" />
-        </div>
+  <?php if (!RASPI_MONITOR_ENABLED) : ?>
+  <form action="system_info" method="POST">
+  <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
+    <div class="row">
+      <div class="mb-3 col-md-6">
+        <label for="code"><?php echo _("Web server port") ;?></label>
+        <input type="text" class="form-control" name="serverPort" value="<?php echo htmlspecialchars($serverPort, ENT_QUOTES); ?>" />
       </div>
-      <div class="row">
-        <div class="mb-3 col-md-6">
-          <label for="code"><?php echo _("Web server bind address") ;?></label>
-          <input type="text" class="form-control" name="serverBind" value="<?php echo htmlspecialchars($serverBind, ENT_QUOTES); ?>" />
-        </div>
+    </div>
+    <div class="row">
+      <div class="mb-3 col-md-6">
+        <label for="code"><?php echo _("Web server bind address") ;?></label>
+        <input type="text" class="form-control" name="serverBind" value="<?php echo htmlspecialchars($serverBind, ENT_QUOTES); ?>" />
       </div>
-      <div class="row">
-        <div class="mb-3 col-md-6">
-          <label for="code"><?php echo _("Diagnostic log size limit (KB)") ;?></label>
-          <input type="text" class="form-control" name="logLimit" value="<?php echo htmlspecialchars($logLimit, ENT_QUOTES); ?>" />
-        </div>
+    </div>
+    <div class="row">
+      <div class="mb-3 col-md-6">
+        <label for="code"><?php echo _("Diagnostic log size limit (KB)") ;?></label>
+        <input type="text" class="form-control" name="logLimit" value="<?php echo htmlspecialchars($logLimit, ENT_QUOTES); ?>" />
       </div>
+    </div>
+    <div class="d-flex flex-wrap gap-2">
       <input type="submit" class="btn btn-outline btn-primary" name="SaveServerSettings" value="<?php echo _("Save settings"); ?>" />
       <input type="submit" class="btn btn-warning" name="RestartLighttpd" value="<?php echo _("Restart lighttpd"); ?>" />
-    </form>
-    <?php endif ?>
+    </div>
+  </form>
+  <?php endif ?>
 </div>
 

--- a/templates/system/basic.php
+++ b/templates/system/basic.php
@@ -64,13 +64,15 @@ include('includes/sysstats.php');
 
       <form action="system_info" method="POST">
         <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
-        <?php if (!RASPI_MONITOR_ENABLED) : ?>
-            <input type="button" class="btn btn-warning" data-bs-toggle="modal" data-bs-target="#system-confirm-reboot" value="<?php echo _("Reboot"); ?>" />
-            <input type="button" class="btn btn-warning" data-bs-toggle="modal" data-bs-target="#system-confirm-shutdown" value="<?php echo _("Shutdown"); ?>" />
-        <?php endif ?>
-        <button type="button" onClick="window.location.reload();" class="btn btn-outline btn-primary"><i class="fas fa-sync-alt"></i> <?php echo _("Refresh") ?></a>
-     </form>
-      </div>
+        <div class="d-flex flex-wrap gap-2">
+          <?php if (!RASPI_MONITOR_ENABLED) : ?>
+              <input type="button" class="btn btn-warning" data-bs-toggle="modal" data-bs-target="#system-confirm-reboot" value="<?php echo _("Reboot"); ?>" />
+              <input type="button" class="btn btn-warning" data-bs-toggle="modal" data-bs-target="#system-confirm-shutdown" value="<?php echo _("Shutdown"); ?>" />
+          <?php endif ?>
+          <button type="button" onClick="window.location.reload();" class="btn btn-outline btn-primary"><i class="fas fa-sync-alt"></i> <?php echo _("Refresh") ?></a>
+        </div>
+      </form>
     </div>
   </div>
+</div>
 

--- a/templates/system/language.php
+++ b/templates/system/language.php
@@ -1,13 +1,15 @@
 <!-- language tab -->  
 <div role="tabpanel" class="tab-pane" id="language">
-    <h4 class="mt-3"><?php echo _("Language settings") ;?></h4>
-    <div class="row">
-      <div class="mb-3 col-md-6">
-        <label for="code"><?php echo _("Select a language"); ?></label>
-        <?php SelectorOptions('locale', $arrLocales, $_SESSION['locale']); ?>
-      </div>
+  <h4 class="mt-3"><?php echo _("Language settings") ;?></h4>
+  <div class="row">
+    <div class="mb-3 col-md-6">
+      <label for="code"><?php echo _("Select a language"); ?></label>
+      <?php SelectorOptions('locale', $arrLocales, $_SESSION['locale']); ?>
     </div>
+  </div>
+  <div class="d-flex flex-wrap gap-2">
     <input type="submit" class="btn btn-outline btn-primary" name="SaveLanguage" value="<?php echo _("Save settings"); ?>" />
-    <button type="button" onClick="window.location.reload();" class="btn btn-outline btn-primary"><i class="fas fa-sync-alt"></i> <?php echo _("Refresh") ?></a>
+    <button type="button" onClick="window.location.reload();" class="btn btn-outline btn-primary"><i class="fas fa-sync-alt"></i> <?php echo _("Refresh") ?></button>
+  </div>
 </div>
 

--- a/templates/system/theme.php
+++ b/templates/system/theme.php
@@ -13,27 +13,29 @@
         <input class="form-control color-input" value="#2b8080" aria-label="color" />
       </div>
     </div>
-      <div class="row">
-        <div class="col-md-6 mb-2">
-        <h5 class="mt-1"><?php echo _("Alert messages"); ?></h5>          
-          <div class="form-check form-switch">
-            <?php $checked = $optAutoclose == 1 ? 'checked="checked"' : '' ?>
-            <input class="form-check-input" id="chxautoclose" name="autoClose" type="checkbox" value="1" <?php echo $checked ?> />
-            <label class="form-check-label" for="chxautoclose"><?php echo _("Automatically close alerts after a specified timeout"); ?></label>
-          </div>
+    <div class="row">
+      <div class="col-md-6 mb-2">
+      <h5 class="mt-1"><?php echo _("Alert messages"); ?></h5>          
+        <div class="form-check form-switch">
+          <?php $checked = $optAutoclose == 1 ? 'checked="checked"' : '' ?>
+          <input class="form-check-input" id="chxautoclose" name="autoClose" type="checkbox" value="1" <?php echo $checked ?> />
+          <label class="form-check-label" for="chxautoclose"><?php echo _("Automatically close alerts after a specified timeout"); ?></label>
         </div>
       </div>
-      <div class="row">
-        <div class="mb-3 col-md-6">
-          <label for="code"><?php echo _("Alert close timeout (milliseconds)") ;?></label>
-          <input type="text" class="form-control" name="alertTimeout" value="<?php echo htmlspecialchars($alertTimeout, ENT_QUOTES); ?>" />
-        </div>
+    </div>
+    <div class="row">
+      <div class="mb-3 col-md-6">
+        <label for="code"><?php echo _("Alert close timeout (milliseconds)") ;?></label>
+        <input type="text" class="form-control" name="alertTimeout" value="<?php echo htmlspecialchars($alertTimeout, ENT_QUOTES); ?>" />
       </div>
+    </div>
+    <div class="d-flex flex-wrap gap-2">
       <?php if (!RASPI_MONITOR_ENABLED) : ?>
       <input type="submit" class="btn btn-outline btn-primary" name="savethemeSettings" value="<?php echo _("Save settings"); ?>" />
       <?php endif; ?>
-      <button type="button" onClick="window.location.reload();" class="btn btn-outline btn-primary"><i class="fas fa-sync-alt"></i> <?php echo _("Refresh") ?></a>
-    </form>
+      <button type="button" onClick="window.location.reload();" class="btn btn-outline btn-primary"><i class="fas fa-sync-alt"></i> <?php echo _("Refresh") ?></button>
+    </div>
+  </form>
 </div>
 
 

--- a/templates/torproxy.php
+++ b/templates/torproxy.php
@@ -1,7 +1,7 @@
     <div class="row">
     <div class="col-lg-12">
       <div class="card"> 
-        <div class="card-header"><i class="fa fa-eye-slash fa-fw"></i> TOR proxy</div>
+        <div class="card-header page-card-header"><i class="fa fa-eye-slash fa-fw"></i> TOR proxy</div>
         <div class="card-body">
             <!-- Nav tabs -->
             <ul class="nav nav-tabs">

--- a/templates/torproxy.php
+++ b/templates/torproxy.php
@@ -4,11 +4,13 @@
         <div class="card-header page-card-header"><i class="fa fa-eye-slash fa-fw"></i> TOR proxy</div>
         <div class="card-body">
             <!-- Nav tabs -->
-            <ul class="nav nav-tabs">
-                <li class="nav-item"><a class="nav-link active" href="#basic" data-bs-toggle="tab">Basic</a></li>
-                <li class="nav-item"><a class="nav-link" href="#relay" data-bs-toggle="tab">Relay</a>
-                </li>
-            </ul>
+            <div class="nav-tabs-wrapper">
+                <ul class="nav nav-tabs">
+                    <li class="nav-item"><a class="nav-link active" href="#basic" data-bs-toggle="tab">Basic</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#relay" data-bs-toggle="tab">Relay</a>
+                    </li>
+                </ul>
+            </div>
 
             <!-- Tab panes -->
             <div class="tab-content">

--- a/templates/wireguard.php
+++ b/templates/wireguard.php
@@ -13,7 +13,7 @@
     <div class="col-lg-12">
       <div class="card">
         <div class="card-header">
-          <div class="row">
+          <div class="row align-items-center">
             <div class="col">
               <span class="ra-wireguard me-2"></span><?php echo _("WireGuard"); ?>
             </div>
@@ -43,7 +43,9 @@
               <?php echo renderTemplate("wg/logging", $__template_data) ?>
             </div><!-- /.tab-content -->
 
-          <?php echo $buttons ?>
+            <div class="d-flex flex-wrap gap-2">
+              <?php echo $buttons ?>
+            </div>
           </form>
         </div><!-- /.card-body -->
         <div class="card-footer"><?php echo _("Information provided by wireguard"); ?></div>

--- a/templates/wireguard.php
+++ b/templates/wireguard.php
@@ -30,11 +30,13 @@
           <form role="form" action="wg_conf" enctype="multipart/form-data" method="POST">
             <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
             <!-- Nav tabs -->
-            <ul class="nav nav-tabs">
-                <li class="nav-item"><a class="nav-link active" id="settingstab" href="#wgsettings" data-bs-toggle="tab"><?php echo _("Settings"); ?></a></li>
-                <li class="nav-item"><a class="nav-link" id="peertab" href="#wgpeers" data-bs-toggle="tab"><?php echo _("Peer"); ?></a></li>
-                <li class="nav-item"><a class="nav-link" id="loggingtab" href="#wglogging" data-bs-toggle="tab"><?php echo _("Logging"); ?></a></li>
-            </ul>
+            <div class="nav-tabs-wrapper">
+              <ul class="nav nav-tabs">
+                  <li class="nav-item"><a class="nav-link active" id="settingstab" href="#wgsettings" data-bs-toggle="tab"><?php echo _("Settings"); ?></a></li>
+                  <li class="nav-item"><a class="nav-link" id="peertab" href="#wgpeers" data-bs-toggle="tab"><?php echo _("Peer"); ?></a></li>
+                  <li class="nav-item"><a class="nav-link" id="loggingtab" href="#wglogging" data-bs-toggle="tab"><?php echo _("Logging"); ?></a></li>
+              </ul>
+            </div>
 
             <!-- Tab panes -->
             <div class="tab-content">

--- a/templates/wireguard.php
+++ b/templates/wireguard.php
@@ -12,7 +12,7 @@
   <div class="row">
     <div class="col-lg-12">
       <div class="card">
-        <div class="card-header">
+        <div class="card-header page-card-header">
           <div class="row align-items-center">
             <div class="col">
               <span class="ra-wireguard me-2"></span><?php echo _("WireGuard"); ?>


### PR DESCRIPTION
In this PR is a handful of visual clean ups of the UI.

- Rework Navbar for breakpoints and mobile
- Prevent wrap of Nav Tabs and make horizontal scroll instead (hide scrollbar visually for better look)
- Wrap buttons for mobile gracefully with horizontal and vertical spacing
- Vertically center items in page card headers with status indicators
- Stack footer text on small screens
- Fix page tabs hash management (set hash on click and navigate to tab content when page loaded with hash)
- Improve UX for DHCP page when saving an interface settings should bring page back to saved interface otherwise default to ap interface
- Rework DHCP/Static IP toggle on DHCP page

## Changes needed for Insiders repo

Noticed that the sidebar open/closed state was persisted across pages. I'd suggest leaving that commented out.

```
all.css - Change values to the following
...
.topbar-avatar {
  width: 38.4px!important;
  height: 38.4px!important;
}
...
```

```
functions.php - make span classes match
...
$avatar = '<span class="text-muted small">' . $userId . '</span>';
...
```

The following files need the following change
- /templates/networking/devices.php
- /templates/networking/wlanrouting.php
- /templates/admin/general.php
- /plugins-available/Captive/templates/main.php
- /plugins-available/Tailscale/templates/main.php
- /plugins-available/Wireshark/templates/main.php
```
...
<div class="d-flex flex-wrap gap-2">
  <?php echo $buttons ?>
</div>
...
```
