### PR TITLE
Move Service Controls

### DIFF
--- a/includes/hostapd.php
+++ b/includes/hostapd.php
@@ -51,7 +51,7 @@ function DisplayHostAPDConfig()
     $logOutput = [];
 
     if (!RASPI_MONITOR_ENABLED) {
-         if (isset($_POST['StartHotspot']) || isset($_POST['RestartHotspot'])) {
+        if (isset($_POST['StartHotspot']) || isset($_POST['RestartHotspot'])) {
             $status->addMessage('Attempting to start hotspot', 'info');
             if ($arrHostapdConf['BridgedEnable'] == 1) {
                 exec('sudo '.RASPI_CONFIG.'/hostapd/servicestart.sh --interface br0 --seconds 1', $return);
@@ -59,7 +59,7 @@ function DisplayHostAPDConfig()
                 exec('sudo '.RASPI_CONFIG.'/hostapd/servicestart.sh --interface uap0 --seconds 1', $return);
             } else {
                 // systemctl expects a unit name like raspap-network-activity@wlan0.service
-                $iface_nonescaped = $_POST['interface'];
+                $iface_nonescaped = $interface;
                 if (preg_match('/^[a-zA-Z0-9_-]+$/', $iface_nonescaped)) { // validate interface name
                     exec('sudo '.RASPI_CONFIG.'/hostapd/servicestart.sh --interface ' .$iface_nonescaped. ' --seconds 1', $return);
                 } else {

--- a/includes/openvpn.php
+++ b/includes/openvpn.php
@@ -40,8 +40,8 @@ function DisplayOpenVPNConfig()
         }
     }
 
-    exec('pidof openvpn | wc -l', $openvpnstatus);
-    $serviceStatus = $openvpnstatus[0] == 0 ? "down" : "up";
+    exec('pidof openvpn', $openvpnstatus, $ovpn_return);
+    $serviceStatus = ($ovpn_return === 0) ? "up" : "down";
     $auth = file(RASPI_OPENVPN_CLIENT_LOGIN, FILE_IGNORE_NEW_LINES);
     $public_ip = get_public_ip();
 

--- a/includes/wireguard.php
+++ b/includes/wireguard.php
@@ -75,9 +75,9 @@ function DisplayWireGuardConfig()
     }
 
     // fetch service status
-    exec('systemctl is-active wg-quick@wg0', $wgstatus);
-    $serviceStatus = $wgstatus[0] == 'inactive' ? "down" : "up";
-    $wg_state = ($wgstatus[0] == 'active' ? true : false );
+    exec('ip link show wg0 2>/dev/null', $wgstatus, $wg_return);
+    $serviceStatus = ($wg_return === 0) ? "up" : "down";
+    $wg_state = ($wg_return === 0);
     $public_ip = get_public_ip();
 
     // fetch uploaded file configs

--- a/templates/adblock.php
+++ b/templates/adblock.php
@@ -7,7 +7,7 @@
 <div class="row">
   <div class="col-lg-12">
     <div class="card">
-      
+
       <div class="card-header page-card-header">
         <div class="d-flex justify-content-between align-items-center">
           <div>
@@ -60,6 +60,7 @@
           </div>
         </form>
       </div><!-- /.card-body -->
+      
       <div class="card-footer"><?php echo _("Information provided by adblock"); ?></div>
     </div><!-- /.card -->
   </div><!-- /.col-lg-12 -->

--- a/templates/adblock.php
+++ b/templates/adblock.php
@@ -7,6 +7,7 @@
 <div class="row">
   <div class="col-lg-12">
     <div class="card">
+      
       <div class="card-header page-card-header">
         <div class="d-flex justify-content-between align-items-center">
           <div>

--- a/templates/adblock.php
+++ b/templates/adblock.php
@@ -1,54 +1,65 @@
-  <?php ob_start() ?>
-    <?php if (!RASPI_MONITOR_ENABLED) : ?>
-      <input type="submit" class="btn btn-outline btn-primary" name="saveadblocksettings" value="<?php echo _("Save settings"); ?>">
-      <?php if ($dnsmasq_state) : ?>
-        <input type="submit" class="btn btn-warning" name="restartadblock" value="<?php echo _("Restart Ad Blocking"); ?>">
-      <?php else : ?>
-        <input type="submit" class="btn btn-success" name="startadblock" value="<?php echo _("Start Ad Blocking"); ?>">
-      <?php endif ?>
-    <?php endif ?>
-  <?php $buttons = ob_get_clean(); ob_end_clean() ?>
+<?php ob_start() ?>
+  <?php if (!RASPI_MONITOR_ENABLED) : ?>
+    <input type="submit" class="btn btn-outline btn-primary" name="saveadblocksettings" value="<?php echo _("Save settings"); ?>">
+  <?php endif ?>
+<?php $buttons = ob_get_clean(); ob_end_clean() ?>
 
-  <div class="row">
-    <div class="col-lg-12">
-      <div class="card">
-        <div class="card-header">
-          <div class="row">
-            <div class="col">
-              <i class="far fa-hand-paper me-2"></i><?php echo _("Ad Blocking"); ?>
-            </div>
-            <div class="col">
+<div class="row">
+  <div class="col-lg-12">
+    <div class="card">
+      <div class="card-header page-card-header">
+        <div class="d-flex justify-content-between align-items-center">
+          <div>
+            <i class="far fa-hand-paper me-2"></i><?php echo _("Ad Blocking"); ?>
+          </div>
+          <form method="POST" action="adblock_conf">
+            <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
+            <div class="btn-group" role="group">
+              <?php if (!RASPI_MONITOR_ENABLED) : ?>
+                <?php if ($dnsmasq_state) : ?>
+                  <button type="submit" class="btn btn-sm btn-warning" title="<?php echo _("Restart Ad Blocking"); ?>" name="restartadblock" >
+                    <i class="fas fa-sync-alt"></i>
+                  </button>
+                <?php else : ?>
+                  <button type="submit" class="btn btn-sm btn-light" title="<?php echo _("Start Ad Blocking"); ?>" name="startadblock" >
+                    <i class="fas fa-play"></i>
+                  </button>
+                <?php endif ?>
+              <?php endif ?>
               <button class="btn btn-light btn-icon-split btn-sm service-status float-end">
                 <span class="icon text-gray-600"><i class="fas fa-circle service-status-<?php echo $serviceStatus ?>"></i></span>
                 <span class="text service-status">adblock <?php echo _($serviceStatus) ?></span>
               </button>
             </div>
-          </div><!-- /.row -->
-        </div><!-- /.card-header -->
-        <div class="card-body">
-        <?php $status->showMessages(); ?>
-          <form role="form" action="adblock_conf" enctype="multipart/form-data" method="POST">
-            <?php echo \RaspAP\Tokens\CSRF::hiddenField();?>
-            <!-- Nav tabs -->
-            <ul class="nav nav-tabs">
-                <li class="nav-item"><a class="nav-link active" id="blocklisttab" href="#adblocklistsettings" data-bs-toggle="tab"><?php echo _("Blocklist settings"); ?></a></li>
-                <li class="nav-item"><a class="nav-link" id="customtab" href="#adblockcustom" data-bs-toggle="tab"><?php echo _("Custom blocklist"); ?></a></li>
-                <li class="nav-item"><a class="nav-link" id="logoutputtab" href="#adblocklogfileoutput" data-bs-toggle="tab"><?php echo _("Logging"); ?></a></li>
-            </ul>
+          </form>
+        </div><!-- /.row -->
+      </div><!-- /.card-header -->
 
-            <!-- Tab panes -->
-            <div class="tab-content">
-              <?php echo renderTemplate("adblock/general", $__template_data) ?>
-              <?php echo renderTemplate("adblock/stats", $__template_data) ?>
-              <?php echo renderTemplate("adblock/custom", $__template_data) ?>
-              <?php echo renderTemplate("adblock/logging", $__template_data) ?>
-            </div><!-- /.tab-content -->
+      <div class="card-body">
+        <?php $status->showMessages(); ?>
+        <form role="form" action="adblock_conf" enctype="multipart/form-data" method="POST">
+          <?php echo \RaspAP\Tokens\CSRF::hiddenField();?>
+          <!-- Nav tabs -->
+          <ul class="nav nav-tabs">
+            <li class="nav-item"><a class="nav-link active" id="blocklisttab" href="#adblocklistsettings" data-bs-toggle="tab"><?php echo _("Blocklist settings"); ?></a></li>
+            <li class="nav-item"><a class="nav-link" id="customtab" href="#adblockcustom" data-bs-toggle="tab"><?php echo _("Custom blocklist"); ?></a></li>
+            <li class="nav-item"><a class="nav-link" id="logoutputtab" href="#adblocklogfileoutput" data-bs-toggle="tab"><?php echo _("Logging"); ?></a></li>
+          </ul>
+
+          <!-- Tab panes -->
+          <div class="tab-content">
+            <?php echo renderTemplate("adblock/general", $__template_data) ?>
+            <?php echo renderTemplate("adblock/stats", $__template_data) ?>
+            <?php echo renderTemplate("adblock/custom", $__template_data) ?>
+            <?php echo renderTemplate("adblock/logging", $__template_data) ?>
+          </div><!-- /.tab-content -->
 
           <?php echo $buttons ?>
-          </form>
-        </div><!-- /.card-body -->
-        <div class="card-footer"><?php echo _("Information provided by adblock"); ?></div>
-      </div><!-- /.card -->
-    </div><!-- /.col-lg-12 -->
-  </div><!-- /.row -->
+        </form>
+      </div><!-- /.card-body -->
+
+      <div class="card-footer"><?php echo _("Information provided by adblock"); ?></div>
+    </div><!-- /.card -->
+  </div><!-- /.col-lg-12 -->
+</div><!-- /.row -->
 

--- a/templates/adblock.php
+++ b/templates/adblock.php
@@ -26,7 +26,7 @@
                   </button>
                 <?php endif ?>
               <?php endif ?>
-              <button class="btn btn-light btn-icon-split btn-sm service-status float-end">
+              <button type="button" class="btn btn-light btn-icon-split btn-sm service-status float-end">
                 <span class="icon text-gray-600"><i class="fas fa-circle service-status-<?php echo $serviceStatus ?>"></i></span>
                 <span class="text service-status">adblock <?php echo _($serviceStatus) ?></span>
               </button>

--- a/templates/adblock.php
+++ b/templates/adblock.php
@@ -7,7 +7,6 @@
 <div class="row">
   <div class="col-lg-12">
     <div class="card">
-
       <div class="card-header page-card-header">
         <div class="d-flex justify-content-between align-items-center">
           <div>

--- a/templates/dhcp.php
+++ b/templates/dhcp.php
@@ -1,12 +1,6 @@
 <?php ob_start() ?>
   <?php if (!RASPI_MONITOR_ENABLED) : ?>
       <input type="submit" class="btn btn-outline btn-primary" value="<?php echo _("Save settings"); ?>" name="savedhcpdsettings" />
-      <?php if ($dnsmasq_state) : ?>
-        <input type="submit" class="btn btn-warning" value="<?php echo _("Stop dnsmasq") ?>" name="stopdhcpd" />
-        <input type="submit" class="btn btn-warning" value="<?php echo _("Restart dnsmasq") ?>" name="restartdhcpd" />
-      <?php else : ?>
-        <input type="submit" class="btn btn-success" value="<?php echo _("Start dnsmasq") ?>" name="startdhcpd" />
-      <?php endif ?>
   <?php endif ?>
 <?php $buttons = ob_get_clean(); ob_end_clean() ?>
 
@@ -14,17 +8,34 @@
   <div class="col-lg-12">
     <div class="card">
 
-      <div class="card-header">
-        <div class="row">
-          <div class="col">
+      <div class="card-header page-card-header">
+        <div class="d-flex justify-content-between align-items-center">
+          <div>
             <i class="fas fa-exchange-alt me-2"></i><?php echo _("DHCP Server"); ?>
           </div>
-          <div class="col">
-            <button class="btn btn-light btn-icon-split btn-sm service-status float-end">
-              <span class="icon text-gray-600"><i class="fas fa-circle service-status-<?php echo $serviceStatus ?>"></i></span>
-              <span class="text service-status">dnsmasq <?php echo _($serviceStatus) ?></span>
-            </button>
-          </div>
+          <form method="POST" action="dhcpd_conf">
+            <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
+            <div class="btn-group" role="group">
+              <?php if (!RASPI_MONITOR_ENABLED) : ?>
+                  <?php if ($dnsmasq_state) : ?>
+                    <button type="submit" class="btn btn-sm btn-danger" title="<?php echo _("Stop dnsmasq") ?>" name="stopdhcpd" >
+                      <i class="fas fa-stop"></i>
+                    </button>
+                    <button type="submit" class="btn btn-sm btn-warning" title="<?php echo _("Restart dnsmasq") ?>" name="restartdhcpd" >
+                      <i class="fas fa-sync-alt"></i>
+                    </button>
+                  <?php else : ?>
+                    <button type="submit" class="btn btn-sm btn-light" title="<?php echo _("Start dnsmasq") ?>" name="startdhcpd" >
+                      <i class="fas fa-play"></i>
+                    </button>
+                  <?php endif ?>
+              <?php endif ?>
+              <button class="btn btn-light btn-icon-split btn-sm service-status float-end">
+                <span class="icon text-gray-600"><i class="fas fa-circle service-status-<?php echo $serviceStatus ?>"></i></span>
+                <span class="text service-status">dnsmasq <?php echo _($serviceStatus) ?></span>
+              </button>
+            </div>
+          </form>
         </div><!-- /.row -->
       </div><!-- /.card-header -->
 

--- a/templates/dhcp.php
+++ b/templates/dhcp.php
@@ -30,7 +30,7 @@
                     </button>
                   <?php endif ?>
               <?php endif ?>
-              <button class="btn btn-light btn-icon-split btn-sm service-status float-end">
+              <button type="button" class="btn btn-light btn-icon-split btn-sm service-status float-end">
                 <span class="icon text-gray-600"><i class="fas fa-circle service-status-<?php echo $serviceStatus ?>"></i></span>
                 <span class="text service-status">dnsmasq <?php echo _($serviceStatus) ?></span>
               </button>

--- a/templates/hostapd.php
+++ b/templates/hostapd.php
@@ -1,31 +1,6 @@
 <?php ob_start() ?>
   <?php if (!RASPI_MONITOR_ENABLED) : ?>
     <input type="submit" class="btn btn-outline btn-primary" id="btnSaveHostapd" name="SaveHostAPDSettings" value="<?php echo _("Save settings"); ?>" />
-    <?php if ($hostapdstatus[0] == 0) : ?>
-      <input type="submit" class="btn btn-success" name="StartHotspot" value="<?php echo  _("Start hotspot"); $msg=_("Starting hotspot"); ?>" data-bs-toggle="modal" data-bs-target="#hostapdModal"/>
-    <?php else : ?>
-      <input type="submit" class="btn btn-warning" name="StopHotspot" value="<?php echo _("Stop hotspot") ?>"/>
-      <input type ="submit" class="btn btn-warning" name="RestartHotspot" value="<?php echo _("Restart hotspot"); $msg=_("Restarting hotspot"); ?>" data-bs-toggle="modal" data-bs-target="#hostapdModal"/>
-    <?php endif ?>
-    <!-- Modal -->
-    <div class="modal fade" id="hostapdModal" tabindex="-1" role="dialog" aria-labelledby="ModalLabel" aria-hidden="true">
-      <div class="modal-dialog" role="document">
-        <div class="modal-content">
-          <div class="modal-header">
-            <div class="modal-title" id="ModalLabel"><i class="fas fa-sync-alt fa-spin me-2"></i><?php echo $msg ?></div>
-          </div>
-          <div class="modal-body">
-            <div class="col-md-12 mb-3 mt-1"><?php echo _("Executing RaspAP service start") ?>...</div>
-            <div class="progress" style="height: 20px;">
-              <div class="progress-bar bg-info" role="progressbar" id="progressBar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="9"></div>
-            </div>
-          </div>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-outline btn-primary" data-bs-dismiss="modal"><?php echo _("Close"); ?></button>
-          </div>
-        </div>
-      </div>
-    </div>
   <?php endif ?>
 <?php $buttons = ob_get_clean(); ob_end_clean() ?>
 
@@ -33,16 +8,54 @@
   <div class="col-lg-12">
     <div class="card">
 
-      <div class="card-header">
-        <div class="row">
-          <div class="col">
+      <div class="card-header page-card-header">
+        <div class="d-flex justify-content-between align-items-center">
+          <div>
             <i class="fas fa-bullseye me-2"></i><?php echo _("Hotspot"); ?>
           </div>
-          <div class="col">
-            <button class="btn btn-light btn-icon-split btn-sm service-status float-end">
-              <span class="icon text-gray-600"><i class="fas fa-circle hostapd-led service-status-<?php echo $serviceStatus ?>"></i></span>
-              <span class="text service-status">hostapd <?php echo _($serviceStatus) ?></span>
-            </button>
+          <div>
+            <form method="POST" action="hostapd_conf">
+              <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
+              <div class="btn-group" role="group">
+                <?php if (!RASPI_MONITOR_ENABLED) : ?>
+                  <?php if ($hostapdstatus[0] == 0) : ?>
+                    <button type="submit" class="btn btn-sm btn-light" title="<?php echo  _("Start hotspot"); $msg=_("Starting hotspot"); ?>" name="StartHotspot" data-bs-toggle="modal" data-bs-target="#hostapdModal">
+                      <i class="fas fa-play"></i>
+                    </button>
+                  <?php else : ?>
+                    <button type="submit" class="btn btn-sm btn-danger" title="<?php echo _("Stop hotspot") ?>" name="StopHotspot" >
+                      <i class="fas fa-stop"></i>
+                    </button>
+                    <button type="submit" class="btn btn-sm btn-warning" title="<?php echo _("Restart hotspot"); $msg=_("Restarting hotspot"); ?>" name="RestartHotspot" data-bs-toggle="modal" data-bs-target="#hostapdModal">
+                      <i class="fas fa-sync-alt"></i>
+                    </button>
+                  <?php endif ?>
+                  <!-- Modal -->
+                  <div class="modal fade" id="hostapdModal" tabindex="-1" role="dialog" aria-labelledby="ModalLabel" aria-hidden="true">
+                    <div class="modal-dialog" role="document">
+                      <div class="modal-content">
+                        <div class="modal-header">
+                          <div class="modal-title" id="ModalLabel"><i class="fas fa-sync-alt fa-spin me-2"></i><?php echo $msg ?></div>
+                        </div>
+                        <div class="modal-body">
+                          <div class="col-md-12 mb-3 mt-1"><?php echo _("Executing RaspAP service start") ?>...</div>
+                          <div class="progress" style="height: 20px;">
+                            <div class="progress-bar bg-info" role="progressbar" id="progressBar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="9"></div>
+                          </div>
+                        </div>
+                        <div class="modal-footer">
+                          <button type="button" class="btn btn-outline btn-primary" data-bs-dismiss="modal"><?php echo _("Close"); ?></button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                <?php endif ?>
+                <button class="btn btn-light btn-icon-split btn-sm service-status float-end">
+                  <span class="icon text-gray-600"><i class="fas fa-circle hostapd-led service-status-<?php echo $serviceStatus ?>"></i></span>
+                  <span class="text service-status">hostapd <?php echo _($serviceStatus) ?></span>
+                </button>
+              </div>
+            </form>
           </div>
         </div><!-- /.row -->
       </div><!-- /.card-header -->

--- a/templates/hostapd.php
+++ b/templates/hostapd.php
@@ -50,7 +50,7 @@
                     </div>
                   </div>
                 <?php endif ?>
-                <button class="btn btn-light btn-icon-split btn-sm service-status float-end">
+                <button type="button" class="btn btn-light btn-icon-split btn-sm service-status float-end">
                   <span class="icon text-gray-600"><i class="fas fa-circle hostapd-led service-status-<?php echo $serviceStatus ?>"></i></span>
                   <span class="text service-status">hostapd <?php echo _($serviceStatus) ?></span>
                 </button>

--- a/templates/openvpn.php
+++ b/templates/openvpn.php
@@ -1,53 +1,63 @@
-  <?php ob_start() ?>
-    <?php ob_start() ?>
-    <?php if (!RASPI_MONITOR_ENABLED) : ?>
-        <input type="submit" class="btn btn-outline btn-primary" name="SaveOpenVPNSettings" value="<?php echo _("Save settings"); ?>" />
-        <?php if ($openvpnstatus[0] == 0) {
-            echo '<input type="submit" class="btn btn-success" name="StartOpenVPN" value="' . _("Start OpenVPN") . '" />' , PHP_EOL;
-          } else {
-            echo '<input type="submit" class="btn btn-warning" name="StopOpenVPN" value="' . _("Stop OpenVPN") . '" />' , PHP_EOL;
-          }
-        ?>
-    <?php endif ?>
-  <?php $buttons = ob_get_clean(); ob_end_clean() ?>
+<?php ob_start() ?>
+  <?php if (!RASPI_MONITOR_ENABLED) : ?>
+    <input type="submit" class="btn btn-outline btn-primary" name="SaveOpenVPNSettings" value="<?php echo _("Save settings"); ?>" />
+  <?php endif ?>
+<?php $buttons = ob_get_clean(); ob_end_clean() ?>
  
-  <div class="row">
-    <div class="col-lg-12">
-      <div class="card">
-        <div class="card-header">
-          <div class="row">
-            <div class="col">
-              <i class="fas fa-key fa-fw me-2"></i><?php echo _("OpenVPN"); ?>
-            </div>
-            <div class="col">
-              <button class="btn btn-light btn-icon-split btn-sm service-status float-end">
-                <span class="icon text-gray-600"><i class="fas fa-circle service-status-<?php echo $serviceStatus ?>"></i></span>
-                <span class="text service-status">openvpn <?php echo _($serviceStatus) ?></span>
-              </button>
-            </div>
-          </div><!-- /.row -->
-        </div><!-- /.card-header -->
-        <div class="card-body">
-        <?php $status->showMessages(); ?>
-          <form role="form" action="openvpn_conf" enctype="multipart/form-data" method="POST">
-            <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
-            <!-- Nav tabs -->
-            <ul class="nav nav-tabs">
-                <li class="nav-item"><a class="nav-link active" id="clienttab" href="#openvpnclient" data-bs-toggle="tab"><?php echo _("Client settings"); ?></a></li>
-                <li class="nav-item"><a class="nav-link" id="configstab" href="#openvpnconfigs" data-bs-toggle="tab"><?php echo _("Configurations"); ?></a></li>
-                <li class="nav-item"><a class="nav-link" id="loggingtab" href="#openvpnlogging" data-bs-toggle="tab"><?php echo _("Logging"); ?></a></li>
-            </ul>
-
-            <!-- Tab panes -->
-            <div class="tab-content">
-              <?php echo renderTemplate("openvpn/general", $__template_data) ?>
-              <?php echo renderTemplate("openvpn/configs", $__template_data) ?>
-              <?php echo renderTemplate("openvpn/logging", $__template_data) ?>
-            </div><!-- /.tab-content -->
-
-            <?php echo $buttons ?>
+<div class="row">
+  <div class="col-lg-12">
+    <div class="card">
+      
+      <div class="card-header page-card-header">
+        <div class="d-flex justify-content-between align-items-center">
+          <div>
+            <i class="fas fa-key fa-fw me-2"></i><?php echo _("OpenVPN"); ?>
+          </div>
+          <form method="POST" action="openvpn_conf">
+              <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
+              <div class="btn-group" role="group">
+                <?php if (!RASPI_MONITOR_ENABLED) : ?>
+                  <?php if ($openvpnstatus[0] == 0) : ?>
+                    <button type="submit" class="btn btn-sm btn-light" title="<?php echo _("Start OpenVPN"); ?>" name="StartOpenVPN" >
+                      <i class="fas fa-play"></i>
+                    </button>
+                  <?php else : ?>
+                    <button type="submit" class="btn btn-sm btn-danger" title="<?php echo _("Stop OpenVPN"); ?>" name="StopOpenVPN" >
+                      <i class="fas fa-stop"></i>
+                    </button>
+                  <?php endif; ?>
+                <?php endif ?>
+                <button class="btn btn-light btn-icon-split btn-sm service-status float-end">
+                  <span class="icon text-gray-600"><i class="fas fa-circle service-status-<?php echo $serviceStatus ?>"></i></span>
+                  <span class="text service-status">openvpn <?php echo _($serviceStatus) ?></span>
+                </button>
+              </div>
           </form>
-        </div><!-- /.card-body -->
+        </div><!-- /.row -->
+      </div><!-- /.card-header -->
+      
+      <div class="card-body">
+        <?php $status->showMessages(); ?>
+        <form role="form" action="openvpn_conf" enctype="multipart/form-data" method="POST">
+          <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
+          <!-- Nav tabs -->
+          <ul class="nav nav-tabs">
+            <li class="nav-item"><a class="nav-link active" id="clienttab" href="#openvpnclient" data-bs-toggle="tab"><?php echo _("Client settings"); ?></a></li>
+            <li class="nav-item"><a class="nav-link" id="configstab" href="#openvpnconfigs" data-bs-toggle="tab"><?php echo _("Configurations"); ?></a></li>
+            <li class="nav-item"><a class="nav-link" id="loggingtab" href="#openvpnlogging" data-bs-toggle="tab"><?php echo _("Logging"); ?></a></li>
+          </ul>
+
+          <!-- Tab panes -->
+          <div class="tab-content">
+            <?php echo renderTemplate("openvpn/general", $__template_data) ?>
+            <?php echo renderTemplate("openvpn/configs", $__template_data) ?>
+            <?php echo renderTemplate("openvpn/logging", $__template_data) ?>
+          </div><!-- /.tab-content -->
+
+          <?php echo $buttons ?>
+        </form>
+      </div><!-- /.card-body -->
+
       <div class="card-footer"><?php echo _("Information provided by openvpn"); ?></div>
     </div><!-- /.card -->
   </div><!-- /.col-lg-12 -->

--- a/templates/openvpn.php
+++ b/templates/openvpn.php
@@ -7,7 +7,7 @@
 <div class="row">
   <div class="col-lg-12">
     <div class="card">
-      
+
       <div class="card-header page-card-header">
         <div class="d-flex justify-content-between align-items-center">
           <div>
@@ -54,7 +54,9 @@
             <?php echo renderTemplate("openvpn/logging", $__template_data) ?>
           </div><!-- /.tab-content -->
 
-          <?php echo $buttons ?>
+          <div class="d-flex flex-wrap gap-2">
+            <?php echo $buttons ?>
+          </div>
         </form>
       </div><!-- /.card-body -->
 

--- a/templates/openvpn.php
+++ b/templates/openvpn.php
@@ -26,7 +26,7 @@
                     </button>
                   <?php endif; ?>
                 <?php endif ?>
-                <button class="btn btn-light btn-icon-split btn-sm service-status float-end">
+                <button type="button" class="btn btn-light btn-icon-split btn-sm service-status float-end">
                   <span class="icon text-gray-600"><i class="fas fa-circle service-status-<?php echo $serviceStatus ?>"></i></span>
                   <span class="text service-status">openvpn <?php echo _($serviceStatus) ?></span>
                 </button>

--- a/templates/openvpn.php
+++ b/templates/openvpn.php
@@ -7,7 +7,6 @@
 <div class="row">
   <div class="col-lg-12">
     <div class="card">
-
       <div class="card-header page-card-header">
         <div class="d-flex justify-content-between align-items-center">
           <div>

--- a/templates/restapi.php
+++ b/templates/restapi.php
@@ -1,49 +1,61 @@
-  <?php ob_start() ?>
-    <?php if (!RASPI_MONITOR_ENABLED) : ?>
+<?php ob_start() ?>
+  <?php if (!RASPI_MONITOR_ENABLED) : ?>
     <input type="submit" class="btn btn-outline btn-primary" name="SaveAPIsettings" value="<?php echo _("Save settings"); ?>" />
-        <?php if ($serviceStatus == 'down') : ?>
-        <input type="submit" class="btn btn-success" name="StartRestAPIservice" value="<?php echo _("Start RestAPI service"); ?>" />
-        <?php else : ?>
-        <input type="submit" class="btn btn-warning" name="StopRestAPIservice" value="<?php echo _("Stop RestAPI service"); ?>" />
-        <?php endif; ?>
-    <?php endif ?>
-  <?php $buttons = ob_get_clean(); ob_end_clean() ?>
+  <?php endif ?>
+<?php $buttons = ob_get_clean(); ob_end_clean() ?>
  
-  <div class="row">
-    <div class="col-lg-12">
-      <div class="card">
-        <div class="card-header">
-          <div class="row">
-            <div class="col">
-              <i class="fas fa-puzzle-piece me-2"></i><?php echo _("RestAPI"); ?>
-            </div>
-            <div class="col">
+<div class="row">
+  <div class="col-lg-12">
+    <div class="card">
+
+      <div class="card-header page-card-header">
+        <div class="d-flex justify-content-between align-items-center">
+          <div>
+            <i class="fas fa-puzzle-piece me-2"></i><?php echo _("RestAPI"); ?>
+          </div>
+          <form method="POST" action="restapi_conf">
+            <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
+            <div class="btn-group" role="group">
+              <?php if (!RASPI_MONITOR_ENABLED) : ?>
+                <?php if ($serviceStatus == 'down') : ?>
+                  <button type="submit" class="btn btn-sm btn-light" title="<?php echo _("Start RestAPI service"); ?>" name="StartRestAPIservice" >
+                    <i class="fas fa-play"></i>
+                  </button>
+                <?php else : ?>
+                  <button type="submit" class="btn btn-sm btn-danger" title="<?php echo _("Stop RestAPI service"); ?>" name="StopRestAPIservice" >
+                    <i class="fas fa-stop"></i>
+                  </button>
+                <?php endif; ?>
+              <?php endif ?>
               <button class="btn btn-light btn-icon-split btn-sm service-status float-end">
                 <span class="icon text-gray-600"><i class="fas fa-circle service-status-<?php echo $serviceStatus ?>"></i></span>
                 <span class="text service-status">restapi.service <?php echo _($serviceStatus) ?></span>
               </button>
             </div>
-          </div><!-- /.row -->
-        </div><!-- /.card-header -->
-        <div class="card-body">
-        <?php $status->showMessages(); ?>
-          <form role="form" action="restapi_conf" method="POST" class="needs-validation" novalidate>
-            <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
-            <!-- Nav tabs -->
-            <ul class="nav nav-tabs">
-                <li class="nav-item"><a class="nav-link active" id="restapisettingstab" href="#restapisettings" data-bs-toggle="tab"><?php echo _("Settings"); ?></a></li>
-                <li class="nav-item"><a class="nav-link" id="restapistatustab" href="#restapistatus" data-bs-toggle="tab"><?php echo _("Status"); ?></a></li>
-            </ul>
-
-            <!-- Tab panes -->
-            <div class="tab-content">
-              <?php echo renderTemplate("restapi/general", $__template_data) ?>
-              <?php echo renderTemplate("restapi/status", $__template_data) ?>
-            </div><!-- /.tab-content -->
-
-            <?php echo $buttons ?>
           </form>
-        </div><!-- /.card-body -->
+        </div><!-- /.row -->
+      </div><!-- /.card-header -->
+
+      <div class="card-body">
+        <?php $status->showMessages(); ?>
+        <form role="form" action="restapi_conf" method="POST" class="needs-validation" novalidate>
+          <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
+          <!-- Nav tabs -->
+          <ul class="nav nav-tabs">
+            <li class="nav-item"><a class="nav-link active" id="restapisettingstab" href="#restapisettings" data-bs-toggle="tab"><?php echo _("Settings"); ?></a></li>
+            <li class="nav-item"><a class="nav-link" id="restapistatustab" href="#restapistatus" data-bs-toggle="tab"><?php echo _("Status"); ?></a></li>
+          </ul>
+
+          <!-- Tab panes -->
+          <div class="tab-content">
+            <?php echo renderTemplate("restapi/general", $__template_data) ?>
+            <?php echo renderTemplate("restapi/status", $__template_data) ?>
+          </div><!-- /.tab-content -->
+
+          <?php echo $buttons ?>
+        </form>
+      </div><!-- /.card-body -->
+
       <div class="card-footer"><?php echo _("Information provided by restapi.service"); ?></div>
     </div><!-- /.card -->
   </div><!-- /.col-lg-12 -->

--- a/templates/restapi.php
+++ b/templates/restapi.php
@@ -27,7 +27,7 @@
                   </button>
                 <?php endif; ?>
               <?php endif ?>
-              <button class="btn btn-light btn-icon-split btn-sm service-status float-end">
+              <button type="button"class="btn btn-light btn-icon-split btn-sm service-status float-end">
                 <span class="icon text-gray-600"><i class="fas fa-circle service-status-<?php echo $serviceStatus ?>"></i></span>
                 <span class="text service-status">restapi.service <?php echo _($serviceStatus) ?></span>
               </button>

--- a/templates/wireguard.php
+++ b/templates/wireguard.php
@@ -1,53 +1,66 @@
-  <?php ob_start() ?>
-    <?php if (!RASPI_MONITOR_ENABLED) : ?>
-      <input type="submit" class="btn btn-outline btn-primary" name="savewgsettings" value="<?php echo _("Save settings"); ?>">
-      <?php if ($wg_state) : ?>
-        <input type="submit" class="btn btn-warning" name="stopwg" value="<?php echo _("Stop WireGuard"); ?>">
-      <?php else : ?>
-        <input type="submit" class="btn btn-success" name="startwg" value="<?php echo _("Start WireGuard"); ?>">
-      <?php endif ?>
-    <?php endif ?>
-  <?php $buttons = ob_get_clean(); ob_end_clean() ?>
+<?php ob_start() ?>
+  <?php if (!RASPI_MONITOR_ENABLED) : ?>
+    <input type="submit" class="btn btn-outline btn-primary" name="savewgsettings" value="<?php echo _("Save settings"); ?>">
+  <?php endif ?>
+<?php $buttons = ob_get_clean(); ob_end_clean() ?>
 
-  <div class="row">
-    <div class="col-lg-12">
-      <div class="card">
-        <div class="card-header">
-          <div class="row">
-            <div class="col">
-              <span class="ra-wireguard me-2"></span><?php echo _("WireGuard"); ?>
-            </div>
-            <div class="col">
+<div class="row">
+  <div class="col-lg-12">
+    <div class="card">
+
+      <div class="card-header page-card-header">
+        <div class="row align-items-center">
+          <div class="col">
+            <span class="ra-wireguard me-2"></span><?php echo _("WireGuard"); ?>
+          </div>
+          <form method="POST" action="wg_conf">
+            <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
+            <div class="btn-group" role="group">
+              <?php if (!RASPI_MONITOR_ENABLED) : ?>
+                <?php if ($wg_state) : ?>
+                  <button type="submit" class="btn btn-sm btn-danger" title="<?php echo _("Stop WireGuard"); ?>" name="stopwg" >
+                    <i class="fas fa-stop"></i>
+                  </button>
+                <?php else : ?>
+                  <button type="submit" class="btn btn-sm btn-light" title="<?php echo _("Start WireGuard"); ?>" name="startwg" >
+                    <i class="fas fa-play"></i>
+                  </button>
+                <?php endif; ?>
+              <?php endif ?>
               <button class="btn btn-light btn-icon-split btn-sm service-status float-end">
                 <span class="icon text-gray-600"><i class="fas fa-circle service-status-<?php echo $serviceStatus ?>"></i></span>
                 <span class="text service-status">wg <?php echo _($serviceStatus) ?></span>
               </button>
             </div>
-          </div><!-- /.row -->
-        </div><!-- /.card-header -->
-        <div class="card-body">
-        <?php $status->showMessages(); ?>
-          <form role="form" action="wg_conf" enctype="multipart/form-data" method="POST">
-            <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
-            <!-- Nav tabs -->
-            <ul class="nav nav-tabs">
-                <li class="nav-item"><a class="nav-link active" id="settingstab" href="#wgsettings" data-bs-toggle="tab"><?php echo _("Settings"); ?></a></li>
-                <li class="nav-item"><a class="nav-link" id="peertab" href="#wgpeers" data-bs-toggle="tab"><?php echo _("Peer"); ?></a></li>
-                <li class="nav-item"><a class="nav-link" id="loggingtab" href="#wglogging" data-bs-toggle="tab"><?php echo _("Logging"); ?></a></li>
-            </ul>
+          </form>
+          </div>
+        </div><!-- /.row -->
+      </div><!-- /.card-header -->
 
-            <!-- Tab panes -->
-            <div class="tab-content">
-              <?php echo renderTemplate("wg/general", $__template_data) ?>
-              <?php echo renderTemplate("wg/peers", $__template_data) ?>
-              <?php echo renderTemplate("wg/logging", $__template_data) ?>
-            </div><!-- /.tab-content -->
+      <div class="card-body">
+        <?php $status->showMessages(); ?>
+        <form role="form" action="wg_conf" enctype="multipart/form-data" method="POST">
+          <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
+          <!-- Nav tabs -->
+          <ul class="nav nav-tabs">
+            <li class="nav-item"><a class="nav-link active" id="settingstab" href="#wgsettings" data-bs-toggle="tab"><?php echo _("Settings"); ?></a></li>
+            <li class="nav-item"><a class="nav-link" id="peertab" href="#wgpeers" data-bs-toggle="tab"><?php echo _("Peer"); ?></a></li>
+            <li class="nav-item"><a class="nav-link" id="loggingtab" href="#wglogging" data-bs-toggle="tab"><?php echo _("Logging"); ?></a></li>
+          </ul>
+
+          <!-- Tab panes -->
+          <div class="tab-content">
+            <?php echo renderTemplate("wg/general", $__template_data) ?>
+            <?php echo renderTemplate("wg/peers", $__template_data) ?>
+            <?php echo renderTemplate("wg/logging", $__template_data) ?>
+          </div><!-- /.tab-content -->
 
           <?php echo $buttons ?>
-          </form>
-        </div><!-- /.card-body -->
-        <div class="card-footer"><?php echo _("Information provided by wireguard"); ?></div>
-      </div><!-- /.card -->
-    </div><!-- /.col-lg-12 -->
-  </div><!-- /.row -->
+        </form>
+      </div><!-- /.card-body -->
+
+      <div class="card-footer"><?php echo _("Information provided by wireguard"); ?></div>
+    </div><!-- /.card -->
+  </div><!-- /.col-lg-12 -->
+</div><!-- /.row -->
 

--- a/templates/wireguard.php
+++ b/templates/wireguard.php
@@ -54,13 +54,13 @@
             <?php echo renderTemplate("wg/logging", $__template_data) ?>
           </div><!-- /.tab-content -->
 
-            <div class="d-flex flex-wrap gap-2">
-              <?php echo $buttons ?>
-            </div>
-          </form>
-        </div><!-- /.card-body -->
-        <div class="card-footer"><?php echo _("Information provided by wireguard"); ?></div>
-      </div><!-- /.card -->
-    </div><!-- /.col-lg-12 -->
-  </div><!-- /.row -->
+          <div class="d-flex flex-wrap gap-2">
+            <?php echo $buttons ?>
+          </div>
+        </form>
+      </div><!-- /.card-body -->
+      <div class="card-footer"><?php echo _("Information provided by wireguard"); ?></div>
+    </div><!-- /.card -->
+  </div><!-- /.col-lg-12 -->
+</div><!-- /.row -->
 

--- a/templates/wireguard.php
+++ b/templates/wireguard.php
@@ -9,8 +9,8 @@
     <div class="card">
 
       <div class="card-header page-card-header">
-        <div class="row align-items-center">
-          <div class="col">
+        <div class="d-flex justify-content-between align-items-center">
+          <div>
             <span class="ra-wireguard me-2"></span><?php echo _("WireGuard"); ?>
           </div>
           <form method="POST" action="wg_conf">
@@ -33,7 +33,6 @@
               </button>
             </div>
           </form>
-          </div>
         </div><!-- /.row -->
       </div><!-- /.card-header -->
 

--- a/templates/wireguard.php
+++ b/templates/wireguard.php
@@ -27,7 +27,7 @@
                   </button>
                 <?php endif; ?>
               <?php endif ?>
-              <button class="btn btn-light btn-icon-split btn-sm service-status float-end">
+              <button type="button" class="btn btn-light btn-icon-split btn-sm service-status float-end">
                 <span class="icon text-gray-600"><i class="fas fa-circle service-status-<?php echo $serviceStatus ?>"></i></span>
                 <span class="text service-status">wg <?php echo _($serviceStatus) ?></span>
               </button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -79,9 +79,9 @@ aggregate-error@^3.0.0:
     indent-string "^4.0.0"
 
 ajv@^6.12.3:
-  version "6.12.4"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.4.tgz#0614facc4522127fa713445c6bfd3ebd376e2234"
-  integrity sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==
+  version "6.14.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.14.0.tgz#fd067713e228210636ebb08c60bd3765d6dbe73a"
+  integrity sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"


### PR DESCRIPTION
The purpose of this PR is to move service control buttons up near the service status indicator.

### Why?
In a few instances there were issues with the service control buttons not being able to function due to form validation that the button was a part of. Moving the service control buttons outside of the general page forms solves this problem entirely. In addition, consolidating this part of the UI make it more clear as to what can be done with the page form (eg save setting) and where to go to manage the service.

<img width="195" height="58" alt="Screenshot 2026-03-06 at 9 35 08 AM" src="https://github.com/user-attachments/assets/818bc399-4b8d-4be5-ba0c-b32d16eba54f" />

### Controls moved
- DHCP
- AdBlock
- HostAPD
- OpenVPN
- WireGuard
- RestAPI

### ToDos
- [x] Verify new OpenVPN controls
- [x] Verify new WireGuard controls
- Check for plugins that need similar changes
  - Tailscale
  - Wireshark
  - CaptivePortal