### PR TITLE
fix: prevent argument injection in OpenVPN config deletion

### DIFF
--- a/ajax/openvpn/del_ovpncfg.php
+++ b/ajax/openvpn/del_ovpncfg.php
@@ -7,9 +7,14 @@ require_once '../../includes/authenticate.php';
 require_once '../../includes/functions.php';
 
 if (isset($_POST['cfg_id'])) {
-    $ovpncfg_id = escapeshellcmd($_POST['cfg_id']);
-    $ovpncfg_files = pathinfo(RASPI_OPENVPN_CLIENT_LOGIN, PATHINFO_DIRNAME).'/'.$ovpncfg_id.'_*.conf';
-    exec("sudo rm $ovpncfg_files", $return);
+    $ovpncfg_id = $_POST['cfg_id'];
+    // Validate cfg_id: only allow alphanumeric, hyphens, underscores (prevent path traversal and argument injection)
+    if (!preg_match('/^[a-zA-Z0-9_-]+$/', $ovpncfg_id)) {
+        echo json_encode(['return' => 'Invalid configuration ID']);
+        exit;
+    }
+    $ovpncfg_dir = escapeshellarg(pathinfo(RASPI_OPENVPN_CLIENT_LOGIN, PATHINFO_DIRNAME));
+    exec("sudo rm " . $ovpncfg_dir . "/" . escapeshellarg($ovpncfg_id . "_*.conf"), $return);
     $jsonData = ['return'=>$return];
     echo json_encode($jsonData);
 }


### PR DESCRIPTION
## Summary

Fix argument injection vulnerability in OpenVPN config deletion endpoint that allows authenticated users to delete arbitrary files as root.

## Problem

`ajax/openvpn/del_ovpncfg.php` uses `escapeshellcmd()` which does **not prevent argument injection**:

```php
$ovpncfg_id = escapeshellcmd($_POST['cfg_id']);
$ovpncfg_files = pathinfo(...).'/'.$ovpncfg_id.'_*.conf';
exec("sudo rm $ovpncfg_files", $return);
```

### Why `escapeshellcmd` is insufficient

`escapeshellcmd()` escapes shell metacharacters (`;`, `|`, `&`, etc.) but does NOT prevent:

1. **Argument injection**: `cfg_id=-rf /` → `sudo rm /path/-rf /_*.conf` — the `-rf` flag is interpreted by `rm`
2. **Path traversal**: `cfg_id=../../etc/important` → deletes files outside the VPN config directory

Since this runs with `sudo`, an attacker with basic auth can **delete any file on the system as root**, leading to denial of service or privilege escalation.

### `escapeshellcmd` vs `escapeshellarg`

| Function | Prevents | Does NOT prevent |
|----------|----------|------------------|
| `escapeshellcmd` | Command chaining (`;`, `\|`, `&`) | Argument/flag injection, path traversal |
| `escapeshellarg` | All injection (wraps in single quotes) | — |

## Fix

1. **Validate** `cfg_id` with allowlist regex: only `[a-zA-Z0-9_-]` characters
2. **Replace** `escapeshellcmd` with `escapeshellarg` for proper argument escaping
3. **Escape** the directory path separately

## Impact

- **Type**: Argument Injection / Arbitrary File Deletion as Root (CWE-88)
- **Affected endpoint**: `ajax/openvpn/del_ovpncfg.php`
- **Risk**: Delete any file on the system as root (DoS, privilege escalation)
- **OWASP**: A03:2021 — Injection