### PR TITLE
Fix: User Interface Tweaks

### DIFF
--- a/app/css/base.css
+++ b/app/css/base.css
@@ -233,6 +233,36 @@ button.btn i:not([class*="service-status"]) {
   font-size: 1.3rem;
 }
 
+/* Improved progress bar */
+.progress.progress-improved {
+  position: relative;
+  overflow: hidden;
+}
+.progress.progress-improved .progress-bar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+  clip-path: inset(0 calc(100% - var(--progress)) 0 0);
+}
+.progress.progress-improved .progress-bar span {
+  position: relative;
+  z-index: 2;
+  color: white;
+}
+.progress.progress-improved[data-text]::before {
+  content: attr(data-text);
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: black;
+  z-index: 0;
+}
+
 /* --- Page Specific --- */
 .nav-tabs-wrapper {
   width: 100%;

--- a/app/css/base.css
+++ b/app/css/base.css
@@ -21,7 +21,8 @@ body {
 
 /* Typography */
 a {
-  color: var(--raspap-brand-color);
+  --bs-link-color: var(--raspap-brand-color);
+  --bs-link-hover-color: var(--raspap-brand-color);
   text-decoration: none;
 }
 

--- a/app/css/base.css
+++ b/app/css/base.css
@@ -461,7 +461,6 @@ button.btn i:not([class*="service-status"]) {
 
 .dashed-lines,
 .solid-lines {
-  --connection-lines-offset: 112px;
   position: absolute;
   top: 0;
   left: 0;

--- a/app/css/base.css
+++ b/app/css/base.css
@@ -132,6 +132,10 @@ button.btn i:not([class*="service-status"]) {
   background-size: calc(0.6em + 0.375rem) calc(0.6em + 0.375rem);
 }
 
+.input-group > .btn {
+  border: 1px solid #ced4da;
+}
+
 .input-group > .input-group-append:not(:last-child) > .btn {
   border-top-right-radius: 0.35rem;
   border-bottom-right-radius: 0.35rem;

--- a/app/css/base.css
+++ b/app/css/base.css
@@ -464,16 +464,17 @@ button.btn i:not([class*="service-status"]) {
   --connection-lines-offset: 112px;
   position: absolute;
   top: 0;
-  left: var(--connection-lines-offset);
+  left: 0;
   width: 100%;
   height: 100%;
   object-fit: contain;
   padding: 1rem;
+  left: 112px;
 }
 
 .dashed-lines-right,
 .solid-lines-right {
-  left: calc(var(--connection-lines-offset) * -1);
+  left: -80;
 }
 
 .solid-lines, .solid-lines-right {
@@ -557,13 +558,6 @@ a.inactive:focus {
 }
 
 @media (max-width: 1200px) {
-  .dashed-lines,
-  .solid-lines {
-    --connection-lines-offset: 70px;
-  }
-  .connections-right .connection-item {
-    margin-left: auto;
-  }
   .connection-item a > span:not(.fa-stack) {
     display: none!important;
   }

--- a/app/css/base.css
+++ b/app/css/base.css
@@ -28,13 +28,12 @@ a {
 
 .info-item {
   text-transform: uppercase;
-  font-size: 0.7em;
+  flex-basis: 125px;
   color: var(--raspap-text-muted);
 }
 
-.info-value {
-  font-size: 0.7rem;
-  margin-left: 0.7rem;
+.info-item, .info-value {
+  font-size: 0.9rem;
 }
 
 .info-item-xs {

--- a/app/css/base.css
+++ b/app/css/base.css
@@ -461,19 +461,19 @@ button.btn i:not([class*="service-status"]) {
 
 .dashed-lines,
 .solid-lines {
+  --connection-lines-offset: 112px;
   position: absolute;
   top: 0;
-  left: 0;
+  left: var(--connection-lines-offset);
   width: 100%;
   height: 100%;
   object-fit: contain;
   padding: 1rem;
-  left: 112px;
 }
 
 .dashed-lines-right,
 .solid-lines-right {
-  left: -80px;
+  left: calc(var(--connection-lines-offset) * -1);
 }
 
 .solid-lines, .solid-lines-right {
@@ -557,6 +557,13 @@ a.inactive:focus {
 }
 
 @media (max-width: 1200px) {
+  .dashed-lines,
+  .solid-lines {
+    --connection-lines-offset: 70px;
+  }
+  .connections-right .connection-item {
+    margin-left: auto;
+  }
   .connection-item a > span:not(.fa-stack) {
     display: none!important;
   }

--- a/app/css/base.css
+++ b/app/css/base.css
@@ -45,6 +45,10 @@ a {
   font-size: 16px;
 }
 
+.text-offwhite {
+  color: var(--raspap-offwhite);
+}
+
 /* Elements */
 .table {
   margin-bottom: 0rem;

--- a/app/css/themes/default.php
+++ b/app/css/themes/default.php
@@ -20,11 +20,8 @@ License: GNU General Public License v3.0
 
 /* Typography */
 a {
-  color: var(--raspap-theme-color);
-}
-
-a:focus, a:hover {
-  color: var(--raspap-theme-darker);
+  --bs-link-color: var(--raspap-theme-color);
+  --bs-link-hover-color: var(--raspap-theme-color);
 }
 
 /* Elements */
@@ -39,37 +36,41 @@ i.fa.fa-bars:hover{
 
 /* Buttons */
 .btn-primary {
-  border-color: var(--raspap-theme-color) !important;
-  background-color: var(--raspap-theme-color) !important;
+  --bs-btn-bg: var(--raspap-theme-color);
+  --bs-btn-border-color: var(--raspap-theme-color);
+  --bs-btn-hover-bg: var(--raspap-theme-darker);
+  --bs-btn-hover-border-color: var(--raspap-theme-darker);
+  --bs-btn-active-bg: var(--raspap-theme-darker);
+  --bs-btn-active-border-color: var(--raspap-theme-darker);
+  --bs-btn-disabled-bg: var(--raspap-theme-lighter);
+  --bs-btn-disabled-border-color: var(--raspap-theme-lighter);
 }
 
-.btn-primary.btn-outline {
-  color: var(--raspap-theme-color) !important;
-  border-color: var(--raspap-theme-color) !important;
-  background-color: #fff !important;
+.btn-outline-primary {
+  --bs-btn-color: var(--raspap-theme-color);
+  --bs-btn-border-color: var(--raspap-theme-color);
+  --bs-btn-hover-bg: var(--raspap-theme-color);
+  --bs-btn-hover-border-color: var(--raspap-theme-color);
+  --bs-btn-active-bg: var(--raspap-theme-color);
+  --bs-btn-active-border-color: var(--raspap-theme-color);
+  --bs-btn-disabled-color: var(--raspap-theme-color);
+  --bs-btn-disabled-border-color: var(--raspap-theme-color);
 }
 
-.btn-primary:hover {
-  color: #fff !important;
-  border-color: var(--raspap-theme-color) !important;
-  background-color: var(--raspap-theme-color) !important;
-}
-
-.btn-primary.btn-outline:disabled {
-  color: var(--raspap-theme-color) !important;
-  border-color: var(--raspap-theme-color) !important;
-  background-color: #fff !important;
+html:not([data-bs-theme="dark"]) .btn-outline-warning {
+  --bs-btn-color: #333;
 }
 
 .btn-light {
-  color: var(--raspap-theme-darker) !important;
+  --bs-btn-color: var(--raspap-theme-darker);
+  --bs-btn-hover-color: var(--raspap-theme-darker);
+  --bs-btn-active-color: var(--raspap-theme-darker);
+  --bs-btn-disabled-color: var(--raspap-theme-darker);
 }
 
-.btn-warning {
-  color: #333;
-}
-.btn-warning:hover {
-    color: #000;
+.btn-link {
+  --bs-link-color: var(--raspap-theme-color);
+  --bs-link-hover-color: var(--raspap-theme-darker);
 }
 
 /* Forms */

--- a/app/css/themes/default.php
+++ b/app/css/themes/default.php
@@ -116,6 +116,11 @@ html:not([data-bs-theme="dark"]) .btn-outline-warning {
 }
 
 /* --- Page Specific --- */
+/* Login */
+.login-brand {
+  color: var(--raspap-theme-color);
+}
+
 /* Dashboard */
 .connection-item,
 .connection-item > i,

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -307,12 +307,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // To auto-close Bootstrap alerts; time is in milliseconds
     const alertTimeout = parseInt(getCookie('alert_timeout'), 10);
-
-    if (!isNaN(alertTimeout) && alertTimeout > 0) {
-        window.setTimeout(function() {
+    window.setTimeout(
+        function() {
             $(".alert").fadeTo(500, 0).slideUp(500, function(){
-            $(this).remove();
+                $(this).remove();
             });
-        }, alertTimeout);
-    }
+        },
+        !isNaN(alertTimeout) && alertTimeout > 0 ? alertTimeout : 5000
+    );
 });

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -107,6 +107,14 @@ document.addEventListener('DOMContentLoaded', () => {
         }).parent().addClass('active');
     });
 
+    // Allows closing of sidebar when content overlay is clicked
+    $(document).on('click', '.sb-sidenav-toggled #layoutSidenav_content', function() {
+        // Only apply on mobile style nav
+        if (window.innerWidth < 992) {
+            $('#sidebarToggle').trigger('click');
+        }
+    });
+
     // Sets focus on a specified tab
     jQuery(function() {
         // Store hash in URL

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -288,6 +288,23 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
+    // Handle stacking of multiple Bootstrap modals
+    $(document).on('show.bs.modal', '.modal', function () {
+        // Calculate increasing z-index based on how many modals are currently visible
+        // 1050 is Bootstrap's base modal z-index
+        const zIndex = 1050 + 10 * $('.modal:visible').length;
+
+        $(this).css('z-index', zIndex);
+
+        // Give the backdrop a slightly lower z-index and mark it as stacked
+        // Small delay ensures Bootstrap has created the backdrop
+        setTimeout(() => {
+            $('.modal-backdrop').not('.modal-stack')
+            .css('z-index', zIndex - 1)
+            .addClass('modal-stack');
+        }, 10);
+    });
+
     // To auto-close Bootstrap alerts; time is in milliseconds
     const alertTimeout = parseInt(getCookie('alert_timeout'), 10);
 

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -185,8 +185,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Session expired login button
     $(document).on("click", "#js-session-expired-login", function(e) {
-        const loginModal = $('#modal-admin-login');
-        const redirectUrl = window.location.pathname;
+        const redirectUrl = window.location.pathname + window.location.hash;
         window.location.href = `/login?action=${encodeURIComponent(redirectUrl)}`;
     });
 

--- a/app/js/ui/dhcp.js
+++ b/app/js/ui/dhcp.js
@@ -69,12 +69,12 @@ export function initDHCP() {
     // DHCP or Static IP option group
     $('#chkstatic').on('change', function() {
         if (this.checked) {
-            $('#chkstatic').closest('.btn').removeClass('btn-outline');
-            $('#chkdhcp').closest('.btn').addClass('btn-outline');
+            $('#chkstatic').closest('.btn').addClass('btn-primary').removeClass('btn-outline-primary');
+            $('#chkdhcp').closest('.btn').addClass('btn-outline-primary').removeClass('btn-primary');
             setStaticFieldsEnabled();
         } else {
-            $('#chkstatic').closest('.btn').addClass('btn-outline');
-            $('#chkdhcp').closest('.btn').removeClass('btn-outline');
+            $('#chkstatic').closest('.btn').addClass('btn-outline-primary').removeClass('btn-primary');
+            $('#chkdhcp').closest('.btn').addClass('btn-primary').removeClass('btn-outline-primary');
         }
     });
 
@@ -88,12 +88,12 @@ export function initDHCP() {
 
     $('#chkdhcp').on('change', function() {
         if (this.checked) {
-            $('#chkdhcp').closest('.btn').removeClass('btn-outline');
-            $('#chkstatic').closest('.btn').addClass('btn-outline');
+            $('#chkdhcp').closest('.btn').addClass('btn-primary').removeClass('btn-outline-primary');
+            $('#chkstatic').closest('.btn').addClass('btn-outline-primary').removeClass('btn-primary');
             setStaticFieldsDisabled();
         } else {
-            $('#chkdhcp').closest('.btn').addClass('btn-outline');
-            $('#chkstatic').closest('.btn').removeClass('btn-outline');
+            $('#chkdhcp').closest('.btn').addClass('btn-outline-primary').removeClass('btn-primary');
+            $('#chkstatic').closest('.btn').addClass('btn-primary').removeClass('btn-outline-primary');
         }
     });
 

--- a/app/js/vendor/speedtestUI.js
+++ b/app/js/vendor/speedtestUI.js
@@ -117,18 +117,18 @@ function startStop(){
 		//speedtest is running, abort
 		s.abort();
 		data=null;
-		I("startStopBtn").className="btn btn-outline btn-primary";
+		I("startStopBtn").className="btn btn-outline-primary";
 		I("server").disabled=false;
 		initUI();
 	}else{
 		//test is not running, begin
-		I("startStopBtn").className="btn btn-outline btn-primary running";
+		I("startStopBtn").className="btn btn-outline-primary running";
 		I("server").disabled=true;
 		s.onupdate=function(data){
             uiData=data;
 		};
 		s.onend=function(aborted){
-            I("startStopBtn").className="btn btn-outline btn-primary";
+            I("startStopBtn").className="btn btn-outline-primary";
             I("server").disabled=false;
             updateUI(true);
             if(!aborted){

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -20,7 +20,7 @@
         <?php echo _("Your session has expired. Please login to continue.") ?>
       </div>
       <div class="modal-footer">
-        <button type="button" id="js-session-expired-login" class="btn btn-outline btn-primary"><?php echo _("Login"); ?></button>
+        <button type="button" id="js-session-expired-login" class="btn btn-outline-primary"><?php echo _("Login"); ?></button>
       </div>
     </div>
   </div>

--- a/src/RaspAP/Plugins/PluginInstaller.php
+++ b/src/RaspAP/Plugins/PluginInstaller.php
@@ -589,11 +589,11 @@ class PluginInstaller
             $manifest = htmlspecialchars(json_encode($manifestData), ENT_QUOTES, 'UTF-8');
 
             if ($installed === true) {
-                $button = '<button type="button" class="btn btn-outline btn-primary btn-sm text-nowrap"
+                $button = '<button type="button" class="btn btn-outline-primary btn-sm text-nowrap"
                     name="plugin-details" data-bs-toggle="modal" data-bs-target="#install-user-plugin"
                     data-plugin-manifest="' .$manifest. '" data-plugin-installed="' .$installed. '">' . _("Installed") .'</button>';
             } elseif (!RASPI_MONITOR_ENABLED) {
-                $button = '<button type="button" class="btn btn-outline btn-primary btn-sm text-nowrap"
+                $button = '<button type="button" class="btn btn-outline-primary btn-sm text-nowrap"
                     name="install-plugin" data-bs-toggle="modal" data-bs-target="#install-user-plugin"
                     data-plugin-manifest="' .$manifest. '" data-repo-public="' .$this->repoPublic. '">' . _("Details") .'</button>';
             }

--- a/templates/about.php
+++ b/templates/about.php
@@ -55,7 +55,7 @@ require_once 'app/lib/Parsedown.php';
           <div id="msgLatest" data-message="<?php echo _("Installed version is the latest release."); ?>"></div>
           <div id="msgInstall" data-message="<?php echo _("Install this update now?"); ?>"></div>
           <button type="button" data-message="<?php echo _("OK"); ?>" id="js-check-dismiss" class="btn btn-outline-secondary" data-bs-dismiss="modal"><?php echo _("Cancel"); ?></button>
-          <button type="submit" id="js-sys-check-update" class="btn btn-outline btn-primary collapse"><?php echo _("OK"); ?></button>
+          <button type="submit" id="js-sys-check-update" class="btn btn-outline-primary collapse"><?php echo _("OK"); ?></button>
         </div>
       </form>
     </div>
@@ -82,7 +82,7 @@ require_once 'app/lib/Parsedown.php';
         <div id="successMsg" data-message="<?php echo _("Success. Refresh this page to confirm the new version."); ?>"></div>
       </div>
       <div class="modal-footer">
-      <button type="button" class="btn btn-outline btn-primary" data-bs-dismiss="modal" disabled id="updateOk" /><?php echo _("OK"); ?></button>
+      <button type="button" class="btn btn-outline-primary" data-bs-dismiss="modal" disabled id="updateOk" /><?php echo _("OK"); ?></button>
       </div>
     </div>
   </div>

--- a/templates/adblock.php
+++ b/templates/adblock.php
@@ -1,6 +1,6 @@
 <?php ob_start() ?>
   <?php if (!RASPI_MONITOR_ENABLED) : ?>
-    <input type="submit" class="btn btn-outline btn-primary" name="saveadblocksettings" value="<?php echo _("Save settings"); ?>">
+    <input type="submit" class="btn btn-outline-primary" name="saveadblocksettings" value="<?php echo _("Save settings"); ?>">
   <?php endif ?>
 <?php $buttons = ob_get_clean(); ob_end_clean() ?>
 

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -1,6 +1,6 @@
 <?php ob_start() ?>
   <?php if (!RASPI_MONITOR_ENABLED) : ?>
-    <input type="submit" class="btn btn-outline btn-primary" name="UpdateAdminPassword" value="<?php echo _("Save settings"); ?>" />
+    <input type="submit" class="btn btn-outline-primary" name="UpdateAdminPassword" value="<?php echo _("Save settings"); ?>" />
     <input type="submit" class="btn btn-warning" name="logout" value="<?php echo _("Logout") ?>" onclick="disableValidation(this.form)"/>
   <?php endif ?>
 <?php $buttons = ob_get_clean(); ob_end_clean() ?>

--- a/templates/configure_client.php
+++ b/templates/configure_client.php
@@ -62,7 +62,7 @@
         <div class="col-md-12 mb-3 mt-1"><?php echo _("Configuring Wifi Client Interface..."); ?></div>
       </div>
       <div class="modal-footer">
-      <button type="button" class="btn btn-outline btn-primary" data-bs-dismiss="modal"><?php echo _("Close"); ?></button>
+      <button type="button" class="btn btn-outline-primary" data-bs-dismiss="modal"><?php echo _("Close"); ?></button>
       </div>
     </div>
   </div>

--- a/templates/dhcp.php
+++ b/templates/dhcp.php
@@ -1,6 +1,6 @@
 <?php ob_start() ?>
   <?php if (!RASPI_MONITOR_ENABLED) : ?>
-      <input type="submit" class="btn btn-outline btn-primary" value="<?php echo _("Save settings"); ?>" name="savedhcpdsettings" />
+      <input type="submit" class="btn btn-outline-primary" value="<?php echo _("Save settings"); ?>" name="savedhcpdsettings" />
   <?php endif ?>
 <?php $buttons = ob_get_clean(); ob_end_clean() ?>
 

--- a/templates/dhcp/clients.php
+++ b/templates/dhcp/clients.php
@@ -1,12 +1,14 @@
 <div class="tab-pane fade" id="client-list">
-  <div class="d-flex justify-content-between align-items-center mt-3 mb-3">
-    <h4 class="m-0 text-nowrap"><?php echo _("Client list"); ?></h4>
-    <button type="button" onClick="window.location.reload();" class="btn btn-primary"><i class="fas fa-sync-alt"></i> <?php echo _("Refresh") ?></button>
-  </div>
+  <h4 class="mt-3 text-nowrap"><?php echo _("Client list"); ?></h4>
   <div class="row">
     <div class="col-lg-12">
       <div class="card mb-3">
-        <div class="card-header"><?php echo _("Active DHCP leases"); ?></div>
+        <div class="card-header">
+          <div class="d-flex justify-content-between align-items-center">
+            <span><?php echo _("Active DHCP leases"); ?></span>
+            <button type="button" onClick="window.location.reload();" class="btn btn-sm btn-primary"><i class="fas fa-sync-alt"></i></button>
+          </div>
+        </div>
         <!-- /.panel-heading -->
         <div class="card-body">
           <div class="table-responsive">

--- a/templates/dhcp/general.php
+++ b/templates/dhcp/general.php
@@ -11,10 +11,10 @@
   <div class="row">
     <div class="mb-3 col-md-6">
       <div class="btn-group" role="group" data-bs-toggle="buttons">
-        <label class="btn btn-primary btn-outline" onclick="setDHCPToggles(false)">
+        <label class="btn btn-outline-primary" onclick="setDHCPToggles(false)">
           <input type="radio" name="adapter-ip" id="chkdhcp" autocomplete="off" class="d-none"> DHCP
         </label>
-        <label class="btn btn-primary btn-outline" onclick="setDHCPToggles(true)">
+        <label class="btn btn-outline-primary" onclick="setDHCPToggles(true)">
           <input type="radio" name="adapter-ip" id="chkstatic" autocomplete="off" class="d-none"> Static IP
         </label>
       </div>

--- a/templates/dhcp/logging.php
+++ b/templates/dhcp/logging.php
@@ -10,7 +10,7 @@
   <div class="form-check form-switch">
     <input class="form-check-input" id="log-queries" type="checkbox" name="log-queries" value="1" <?php echo !empty($conf['log-queries']) ? ' checked="checked"' : "" ?> aria-describedby="log-dhcp-queries">
     <label class="form-check-label align-middle" for="log-queries"><?php echo _("Log DNS queries") ?></label>
-    <input type="button" class="btn btn-outline btn-warning btn-sm align-top ms-4" id="js-cleardnsmasq-log" value="<?php echo _("Clear log"); ?>" />
+    <input type="button" class="btn btn-outline-warning btn-sm align-top ms-4" id="js-cleardnsmasq-log" value="<?php echo _("Clear log"); ?>" />
   </div>
 
   <div class="row">

--- a/templates/hostapd.php
+++ b/templates/hostapd.php
@@ -1,6 +1,6 @@
 <?php ob_start() ?>
   <?php if (!RASPI_MONITOR_ENABLED) : ?>
-    <input type="submit" class="btn btn-outline btn-primary" id="btnSaveHostapd" name="SaveHostAPDSettings" value="<?php echo _("Save settings"); ?>" />
+    <input type="submit" class="btn btn-outline-primary" id="btnSaveHostapd" name="SaveHostAPDSettings" value="<?php echo _("Save settings"); ?>" />
   <?php endif ?>
 <?php $buttons = ob_get_clean(); ob_end_clean() ?>
 
@@ -90,7 +90,7 @@
         </div>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-outline btn-primary" data-bs-dismiss="modal"><?php echo _("Close"); ?></button>
+        <button type="button" class="btn btn-outline-primary" data-bs-dismiss="modal"><?php echo _("Close"); ?></button>
       </div>
     </div>
   </div>

--- a/templates/hostapd/logging.php
+++ b/templates/hostapd/logging.php
@@ -7,7 +7,7 @@
     <?php $checked = $arrHostapdConf['LogEnable'] == 1 ? 'checked="checked"' : '' ?>
     <input class="form-check-input" id="chxlogenable" name="logEnable" type="checkbox" value="1" <?php echo $checked ?> />
     <label class="form-check-label align-middle" for="chxlogenable"><?php echo _("Logfile output"); ?></label>
-    <input type="button" class="btn btn-outline btn-warning btn-sm align-top ms-2" id="js-clearhostapd-log" value="<?php echo _("Clear log"); ?>" />
+    <input type="button" class="btn btn-outline-warning btn-sm align-top ms-2" id="js-clearhostapd-log" value="<?php echo _("Clear log"); ?>" />
   </div>
 
   <div class="row">

--- a/templates/hostapd/security.php
+++ b/templates/hostapd/security.php
@@ -19,7 +19,7 @@
       <label for="txtwpapassphrase"><?php echo _("Pre-shared key (PSK)"); ?></label>
       <div class="input-group has-validation">
         <input type="text" class="form-control" id="txtwpapassphrase" name="wpa_passphrase" value="<?php echo htmlspecialchars($arrConfig['wpa_passphrase'], ENT_QUOTES); ?>" required />
-        <div class="input-group-text" id="gen_wpa_passphrase"><i class="fa-solid fa-wand-magic-sparkles"></i></div>
+        <button type="button" class="btn btn-light" id="gen_wpa_passphrase"><i class="fa-solid fa-wand-magic-sparkles"></i></button>
         <div class="invalid-feedback">
           <?php echo _("Please provide a valid PSK."); ?>
         </div>

--- a/templates/login.php
+++ b/templates/login.php
@@ -30,7 +30,7 @@
                   </div>
 
                 </div>
-                <button type="submit" class="btn btn-outline btn-admin-login rounded-pill w-75 mt-4"><?php echo _("Login") ?></button>
+                <button type="submit" class="btn btn-primary rounded-pill w-75 mt-4"><?php echo _("Login") ?></button>
                 <div class="small mt-2"><a href="https://docs.raspap.com/authentication/#restoring-defaults" target="_blank"><?php echo _("Forgot password") ?></a></div>
                 <img src="app/img/uri-qr-code.php?uri=https://docs.raspap.com/authentication/" class="figure-img img-fluid mt-2" alt="RaspAP docs" style="width:75px;">
               </form>

--- a/templates/login.php
+++ b/templates/login.php
@@ -15,24 +15,22 @@
             </div>
             <div class="text-center mb-4">
               <form id="admin-login-form" action="login" method="POST" class="needs-validation" novalidate>
-              <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
+                <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
                 <div class="form-group">
                   <input type="hidden" name="login-auth">
                   <input type="hidden" id="redirect-url" name="redirect-url" value="<?php echo htmlspecialchars($redirectUrl, ENT_QUOTES, 'UTF-8'); ?>">
                   <input type="text" class="form-control" id="username" name="username" placeholder="<?php echo _("Username") ?>" required>
                 </div>
-                <div class="mt-2">
-                  <div class="input-group has-validation">
-                    <input type="password" class="form-control rounded-start border-end-0 no-right-radius" id="password" name="password" placeholder="<?php echo _("Password") ?>" required>
-                    <button class="btn bg-white btn-passwd-append border-start-0 js-toggle-password" type="button" id="passwd-toggle" data-bs-target="[name=password]" data-toggle-with="fas fa-eye-slash text-secondary text-opacity-50">
-                      <i class="fas fa-eye text-secondary text-opacity-50"></i>
-                    </button>
-                  </div>
-
+                <div class="input-group has-validation mt-2">
+                  <input type="password" class="form-control rounded-start border-end-0 no-right-radius" id="password" name="password" placeholder="<?php echo _("Password") ?>" required>
+                  <button class="btn bg-white btn-passwd-append border-start-0 js-toggle-password" type="button" id="passwd-toggle" data-bs-target="[name=password]" data-toggle-with="fas fa-eye-slash text-secondary text-opacity-50">
+                    <i class="fas fa-eye text-secondary text-opacity-50"></i>
+                  </button>
                 </div>
                 <button type="submit" class="btn btn-primary rounded-pill w-75 mt-4"><?php echo _("Login") ?></button>
                 <div class="small mt-2"><a href="https://docs.raspap.com/authentication/#restoring-defaults" target="_blank"><?php echo _("Forgot password") ?></a></div>
-                <img src="app/img/uri-qr-code.php?uri=https://docs.raspap.com/authentication/" class="figure-img img-fluid mt-2" alt="RaspAP docs" style="width:75px;">
+                <img src="app/img/uri-qr-code.php?uri=https://docs.raspap.com/authentication/" class="figure-img img-fluid mt-5" alt="RaspAP docs" style="width:75px;">
+                <div><span class="small text-offwhite"><?= _('Scan for Login Help'); ?></span></div>
               </form>
             </div>
           </div><!-- /.col -->

--- a/templates/networking/diagnostics.php
+++ b/templates/networking/diagnostics.php
@@ -8,7 +8,7 @@
       <p id="message"><span class="loadCircle"></span><?php echo _("Selecting a server"); ?>...</p>
     </div>
     <div id="testWrapper" class="hidden">
-      <button id="startStopBtn" type="button" class="btn btn-outline btn-primary" onclick="startStop()"></button>
+      <button id="startStopBtn" type="button" class="btn btn-outline-primary" onclick="startStop()"></button>
       <a class="privacy" href="#" onclick="I('privacyPolicy').style.display=''"><?php echo _("Privacy"); ?></a>
 
       <div class="col-sm-4 centered">

--- a/templates/networking/general.php
+++ b/templates/networking/general.php
@@ -1,7 +1,7 @@
 <div role="tabpanel" class="tab-pane fade show active" id="summary">
   <div class="d-flex justify-content-between align-items-center mt-3">
     <h4><?php echo _("Internet connection"); ?></h4>
-    <button type="button" onClick="window.location.reload();" class="btn btn-sm btn-outline btn-primary"><i class="fas fa-sync-alt"></i> <?php echo _("Refresh") ?></button>
+    <button type="button" onClick="window.location.reload();" class="btn btn-sm btn-outline-primary"><i class="fas fa-sync-alt"></i> <?php echo _("Refresh") ?></button>
   </div>
   <div class="row">
     <div class="col-sm-12">

--- a/templates/networking/general.php
+++ b/templates/networking/general.php
@@ -1,102 +1,101 @@
-  <div role="tabpanel" class="tab-pane fade show active" id="summary">
-    <div class="d-flex justify-content-between align-items-center mt-3">
-      <h4><?php echo _("Internet connection"); ?></h4>
-      <button type="button" onClick="window.location.reload();" class="btn btn-sm btn-outline btn-primary"><i class="fas fa-sync-alt"></i> <?php echo _("Refresh") ?></button>
+<div role="tabpanel" class="tab-pane fade show active" id="summary">
+  <div class="d-flex justify-content-between align-items-center mt-3">
+    <h4><?php echo _("Internet connection"); ?></h4>
+    <button type="button" onClick="window.location.reload();" class="btn btn-sm btn-outline btn-primary"><i class="fas fa-sync-alt"></i> <?php echo _("Refresh") ?></button>
+  </div>
+  <div class="row">
+    <div class="col-sm-12">
+      <div class="table-responsive">
+        <table class="table">
+          <thead>
+            <tr>
+              <th><?php echo _("Interface"); ?></th>
+              <th><?php echo _("IP Address"); ?></th>
+              <th><?php echo _("Gateway"); ?></th>
+              <th colspan="2"><?php echo _("Internet Access"); ?></th>
+            </tr>
+          </thead>
+          <tbody>
+            <?php if (isset($routeInfo["error"]) || empty($routeInfo)): ?>
+            <tr><td colspan=5>No route to the internet found</td></tr>
+            <?php else: ?>
+              <?php foreach($routeInfo as $route): ?>
+                <tr>
+                  <td><?php echo $route['interface'] ?></td>
+                  <td><?php echo $route['ip-address'] ?></td>
+                  <td><?php echo $route['gateway'] ?><br><?php $route['gw-name'] ?></td>
+                  <?php if ($route['isAP']): ?>
+                    <td>
+                      <p class="m-0">Access point</p>
+                    </td>
+                  <?php else: ?>
+                    <td>
+                      <p class="m-0"  data-bs-toggle="tooltip" data-bs-placement="left" title="<?php echo "ping ".RASPI_ACCESS_CHECK_IP ?>">
+                        <i class="fas <?php echo $route["access-ip"] ? "fa-check" : "fa-times"; ?>" ></i> <?php echo "IP" ?>
+                      </p>
+                      <p class="m-0" data-bs-toggle="tooltip" data-bs-placement="left" title="<?php echo "ping ".RASPI_ACCESS_CHECK_DNS ?>">
+                        <i class="fas <?php echo $route["access-dns"] ? "fa-check" : "fa-times"; ?>" ></i> <?php echo "DNS" ?>
+                      </p>
+                      <p class="m-0" data-bs-toggle="tooltip" data-bs-placement="left" title="<?php echo RASPI_ACCESS_CHECK_URL ?>">
+                        <i class="fas <?php echo $route["access-url"] ? "fa-check" : "fa-times"; ?>" ></i> <?php echo "HTTP" ?>
+                      </p>
+                    </td>
+                  <?php endif ?>
+                </tr>
+              <?php endforeach ?>
+            <?php endif ?>
+          </tbody>
+        </table>
+      </div>
     </div>
-    <div class="row">
-      <div class="col-sm-12">
-        <div class="table-responsive">
-          <table class="table">
-            <thead>
-              <tr>
-                <th><?php echo _("Interface"); ?></th>
-                <th><?php echo _("IP Address"); ?></th>
-                <th><?php echo _("Gateway"); ?></th>
-                <th colspan="2"><?php echo _("Internet Access"); ?></th>
-              </tr>
-            </thead>
-            <tbody>
-              <?php if (isset($routeInfo["error"]) || empty($routeInfo)): ?>
-              <tr><td colspan=5>No route to the internet found</td></tr>
-              <?php else: ?>
-                <?php foreach($routeInfo as $route): ?>
+  </div>
+
+  <h4 class="mt-3"><?php echo _("Routing table"); ?></h4>
+  <div class="card h-100 w-100">
+    <div class="card-header">
+      <div class="d-flex justify-content-between align-items-center">
+        <span><?php echo _("raw output") ?></span>
+        <button type="button" onClick="window.location.reload();" class="btn btn-sm btn-primary"><i class="fas fa-sync-alt"></i></button>
+      </div>
+    </div>
+    <div class="card-body">
+      <div class="row">
+        <div class="col-sm-12">
+          <div class="table-responsive">
+            <table class="table">
+              <tbody>
+                <?php foreach($routeInfoRaw as $route): ?>
                   <tr>
-                    <td><?php echo $route['interface'] ?></td>
-                    <td><?php echo $route['ip-address'] ?></td>
-                    <td><?php echo $route['gateway'] ?><br><?php $route['gw-name'] ?></td>
-                    <?php if ($route['isAP']): ?>
-                      <td>
-                        <p class="m-0">Access point</p>
-                      </td>
-                    <?php else: ?>
-                      <td>
-                        <p class="m-0"  data-bs-toggle="tooltip" data-bs-placement="left" title="<?php echo "ping ".RASPI_ACCESS_CHECK_IP ?>">
-                          <i class="fas <?php echo $route["access-ip"] ? "fa-check" : "fa-times"; ?>" ></i> <?php echo "IP" ?>
-                        </p>
-                        <p class="m-0" data-bs-toggle="tooltip" data-bs-placement="left" title="<?php echo "ping ".RASPI_ACCESS_CHECK_DNS ?>">
-                          <i class="fas <?php echo $route["access-dns"] ? "fa-check" : "fa-times"; ?>" ></i> <?php echo "DNS" ?>
-                        </p>
-                        <p class="m-0" data-bs-toggle="tooltip" data-bs-placement="left" title="<?php echo RASPI_ACCESS_CHECK_URL ?>">
-                          <i class="fas <?php echo $route["access-url"] ? "fa-check" : "fa-times"; ?>" ></i> <?php echo "HTTP" ?>
-                        </p>
-                      </td>
-                    <?php endif ?>
+                    <pre class="unstyled"><?php echo $route; ?></pre>
                   </tr>
                 <?php endforeach ?>
-              <?php endif ?>
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
-
-    <h4 class="mt-3"><?php echo _("Routing table"); ?></h4>
-    <div class="card h-100 w-100">
-      <div class="card-header">
-        <div class="d-flex justify-content-between align-items-center">
-          <span><?php echo _("raw output") ?></span>
-          <button type="button" onClick="window.location.reload();" class="btn btn-sm btn-primary"><i class="fas fa-sync-alt"></i></button>
-        </div>
-      </div>
-      <div class="card-body">
-        <div class="row">
-          <div class="col-sm-12">
-            <div class="table-responsive">
-              <table class="table">
-                <tbody>
-                  <?php foreach($routeInfoRaw as $route): ?>
-                    <tr>
-                      <pre class="unstyled"><?php echo $route; ?></pre>
-                    </tr>
-                  <?php endforeach ?>
-                </tbody>
-              </table>
-            </div>
+              </tbody>
+            </table>
           </div>
         </div>
       </div>
     </div>
+  </div>
 
-    <h4 class="mt-3"><?php echo _("Current settings") ?></h4>
-    <div class="row">
-      <?php if (!$bridgedEnabled) : // No interface details when bridged ?>
-        <?php foreach ($interfaces as $interface): ?>
-          <?php $if_quoted = htmlspecialchars($interface, ENT_QUOTES) ?>
-          <div class="col-md mb-3">
-            <div class="card h-100 w-100">
-              <div class="card-header">
-                <div class="d-flex justify-content-between align-items-center">
-                  <span><?php echo $if_quoted ?></span>
-                  <button type="button" onClick="window.location.reload();" class="btn btn-sm btn-primary"><i class="fas fa-sync-alt"></i></button>
-                </div>
-              </div>
-              <div class="card-body">
-                <pre class="unstyled" id="<?php echo $if_quoted ?>-summary"></pre>
+  <h4 class="mt-3"><?php echo _("Current settings") ?></h4>
+  <div class="row">
+    <?php if (!$bridgedEnabled) : // No interface details when bridged ?>
+      <?php foreach ($interfaces as $interface): ?>
+        <?php $if_quoted = htmlspecialchars($interface, ENT_QUOTES) ?>
+        <div class="col-md mb-3">
+          <div class="card h-100 w-100">
+            <div class="card-header">
+              <div class="d-flex justify-content-between align-items-center">
+                <span><?php echo $if_quoted ?></span>
+                <button type="button" onClick="window.location.reload();" class="btn btn-sm btn-primary"><i class="fas fa-sync-alt"></i></button>
               </div>
             </div>
+            <div class="card-body">
+              <pre class="unstyled" id="<?php echo $if_quoted ?>-summary"></pre>
+            </div>
           </div>
-        <?php endforeach ?>
-      <?php endif ?>
-    </div><!-- /.row -->
-  </div><!-- /.tabpanel -->
-
+        </div>
+      <?php endforeach ?>
+    <?php endif ?>
+  </div><!-- /.row -->
+</div><!-- /.tabpanel -->

--- a/templates/networking/general.php
+++ b/templates/networking/general.php
@@ -1,5 +1,5 @@
 <div role="tabpanel" class="tab-pane fade show active" id="summary">
-  <div class="d-flex justify-content-between align-items-center mt-3">
+  <div class="d-flex justify-content-between align-items-center mt-3 mb-2">
     <h4><?php echo _("Internet connection"); ?></h4>
     <button type="button" onClick="window.location.reload();" class="btn btn-sm btn-outline-primary"><i class="fas fa-sync-alt"></i> <?php echo _("Refresh") ?></button>
   </div>

--- a/templates/networking/general.php
+++ b/templates/networking/general.php
@@ -1,5 +1,8 @@
   <div role="tabpanel" class="tab-pane fade show active" id="summary">
-    <h4 class="mt-3"><?php echo _("Internet connection"); ?></h4>
+    <div class="d-flex justify-content-between align-items-center mt-3">
+      <h4><?php echo _("Internet connection"); ?></h4>
+      <button type="button" onClick="window.location.reload();" class="btn btn-sm btn-outline btn-primary"><i class="fas fa-sync-alt"></i> <?php echo _("Refresh") ?></button>
+    </div>
     <div class="row">
       <div class="col-sm-12">
         <div class="table-responsive">
@@ -49,7 +52,12 @@
 
     <h4 class="mt-3"><?php echo _("Routing table"); ?></h4>
     <div class="card h-100 w-100">
-      <div class="card-header"><?php echo _("raw output") ?></div>
+      <div class="card-header">
+        <div class="d-flex justify-content-between align-items-center">
+          <span><?php echo _("raw output") ?></span>
+          <button type="button" onClick="window.location.reload();" class="btn btn-sm btn-primary"><i class="fas fa-sync-alt"></i></button>
+        </div>
+      </div>
       <div class="card-body">
         <div class="row">
           <div class="col-sm-12">
@@ -76,7 +84,12 @@
           <?php $if_quoted = htmlspecialchars($interface, ENT_QUOTES) ?>
           <div class="col-md mb-3">
             <div class="card h-100 w-100">
-              <div class="card-header"><?php echo $if_quoted ?></div>
+              <div class="card-header">
+                <div class="d-flex justify-content-between align-items-center">
+                  <span><?php echo $if_quoted ?></span>
+                  <button type="button" onClick="window.location.reload();" class="btn btn-sm btn-primary"><i class="fas fa-sync-alt"></i></button>
+                </div>
+              </div>
               <div class="card-body">
                 <pre class="unstyled" id="<?php echo $if_quoted ?>-summary"></pre>
               </div>
@@ -85,8 +98,5 @@
         <?php endforeach ?>
       <?php endif ?>
     </div><!-- /.row -->
-
-    <button type="button" onClick="window.location.reload();" class="btn btn-outline btn-primary"><i class="fas fa-sync-alt"></i> <?php echo _("Refresh") ?></a>
-
   </div><!-- /.tabpanel -->
 

--- a/templates/openvpn.php
+++ b/templates/openvpn.php
@@ -1,6 +1,6 @@
 <?php ob_start() ?>
   <?php if (!RASPI_MONITOR_ENABLED) : ?>
-    <input type="submit" class="btn btn-outline btn-primary" name="SaveOpenVPNSettings" value="<?php echo _("Save settings"); ?>" />
+    <input type="submit" class="btn btn-outline-primary" name="SaveOpenVPNSettings" value="<?php echo _("Save settings"); ?>" />
   <?php endif ?>
 <?php $buttons = ob_get_clean(); ob_end_clean() ?>
  

--- a/templates/openvpn/logging.php
+++ b/templates/openvpn/logging.php
@@ -6,7 +6,7 @@
   <div class="form-check form-switch">
     <input class="form-check-input" id="log-openvpn" type="checkbox" name="log-openvpn" value="1" <?php echo $logEnable ? ' checked="checked"' : "" ?> aria-describedby="log-openvpn">
     <label class="form-check-label align-middle" for="log-openvpn"><?php echo _("Enable logging") ?></label>
-    <input type="button" class="btn btn-outline btn-warning btn-sm align-top ms-2" id="js-clearopenvpn-log" value="<?php echo _("Clear log"); ?>" />
+    <input type="button" class="btn btn-outline-warning btn-sm align-top ms-2" id="js-clearopenvpn-log" value="<?php echo _("Clear log"); ?>" />
   </div>
   <div class="row">
     <div class="mb-3 col-md-8 mt-2">

--- a/templates/provider.php
+++ b/templates/provider.php
@@ -1,6 +1,6 @@
   <?php ob_start() ?>
     <?php if (!RASPI_MONITOR_ENABLED) : ?>
-    <input type="submit" <?php echo $ctlState; ?> class="btn btn-outline btn-primary <?php echo $ctlState; ?>" name="SaveProviderSettings" value="<?php echo _("Save settings"); ?>" />
+    <input type="submit" <?php echo $ctlState; ?> class="btn btn-outline-primary <?php echo $ctlState; ?>" name="SaveProviderSettings" value="<?php echo _("Save settings"); ?>" />
         <?php if ($serviceStatus == 'down') : ?>
         <input type="submit" <?php echo $ctlState; ?> class="btn btn-success <?php echo $ctlState; ?>" name="StartProviderVPN" value="<?php echo sprintf(_("Connect %s"), $providerName); ?>" />
         <?php else : ?>

--- a/templates/restapi.php
+++ b/templates/restapi.php
@@ -1,6 +1,6 @@
 <?php ob_start() ?>
   <?php if (!RASPI_MONITOR_ENABLED) : ?>
-    <input type="submit" class="btn btn-outline btn-primary" name="SaveAPIsettings" value="<?php echo _("Save settings"); ?>" />
+    <input type="submit" class="btn btn-outline-primary" name="SaveAPIsettings" value="<?php echo _("Save settings"); ?>" />
   <?php endif ?>
 <?php $buttons = ob_get_clean(); ob_end_clean() ?>
  

--- a/templates/restapi/general.php
+++ b/templates/restapi/general.php
@@ -12,7 +12,7 @@
           <label for="txtapikey"><?php echo _("API Key"); ?></label>
           <div class="input-group has-validation">
               <input type="text" class="form-control" id="txtapikey" name="txtapikey" value="<?php echo htmlspecialchars($apiKey, ENT_QUOTES); ?>" required />
-              <div class="input-group-text" id="gen_apikey"><i class="fa-solid fa-wand-magic-sparkles"></i></div>
+              <button type="button" class="btn btn-light" id="gen_apikey"><i class="fa-solid fa-wand-magic-sparkles"></i></button>
               <div class="invalid-feedback">
                 <?php echo _("Please provide a valid API key."); ?>
               </div>

--- a/templates/system/advanced.php
+++ b/templates/system/advanced.php
@@ -23,7 +23,7 @@
       </div>
     </div>
     <div class="d-flex flex-wrap gap-2">
-      <input type="submit" class="btn btn-outline btn-primary" name="SaveServerSettings" value="<?php echo _("Save settings"); ?>" />
+      <input type="submit" class="btn btn-outline-primary" name="SaveServerSettings" value="<?php echo _("Save settings"); ?>" />
       <input type="submit" class="btn btn-warning" name="RestartLighttpd" value="<?php echo _("Restart lighttpd"); ?>" />
     </div>
   </form>

--- a/templates/system/basic.php
+++ b/templates/system/basic.php
@@ -69,7 +69,7 @@ include('includes/sysstats.php');
               <input type="button" class="btn btn-warning" data-bs-toggle="modal" data-bs-target="#system-confirm-reboot" value="<?php echo _("Reboot"); ?>" />
               <input type="button" class="btn btn-warning" data-bs-toggle="modal" data-bs-target="#system-confirm-shutdown" value="<?php echo _("Shutdown"); ?>" />
           <?php endif ?>
-          <button type="button" onClick="window.location.reload();" class="btn btn-outline btn-primary"><i class="fas fa-sync-alt"></i> <?php echo _("Refresh") ?></a>
+          <button type="button" onClick="window.location.reload();" class="btn btn-outline-primary"><i class="fas fa-sync-alt"></i> <?php echo _("Refresh") ?></a>
         </div>
       </form>
     </div>

--- a/templates/system/basic.php
+++ b/templates/system/basic.php
@@ -6,72 +6,105 @@ include('includes/sysstats.php');
 <!-- basic tab -->
 <div role="tabpanel" class="tab-pane fade show active" id="basic">
   <div class="row">
-    <div class="col-lg-6">
+    <div class="col-md-8">
       <h4 class="mt-3"><?php echo _("System Information"); ?></h4>
-        <div class="row ms-1">
-          <div class="col-4">
-            <img class="device-illustration mx-3 my-2" src="app/img/devices/<?php echo $deviceImage; ?>" alt="<?php echo htmlspecialchars($revision, ENT_QUOTES); ?>"></a>
+
+      <div class="d-flex justify-content-center mb-3">
+        <img class="device-illustration mx-3 my-2" src="app/img/devices/<?php echo $deviceImage; ?>" alt="<?php echo htmlspecialchars($revision, ENT_QUOTES); ?>"></a>
+      </div>
+
+      <div class="d-flex justify-content-center mb-3">
+        <form action="system_info" method="POST">
+          <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
+          <div class="d-flex flex-wrap gap-2">
+            <?php if (!RASPI_MONITOR_ENABLED) : ?>
+              <button type="button" class="btn btn-warning" data-bs-toggle="modal" data-bs-target="#system-confirm-reboot">
+                <i class="fa-solid fa-arrows-rotate"></i>
+                <?php echo _("Reboot"); ?>
+              </button>
+              <button type="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#system-confirm-shutdown">
+                <i class="fas fa-power-off"></i>
+                <?php echo _("Shutdown"); ?>
+              </button>
+            <?php endif ?>
           </div>
-          <div class="col-sm-10">
-            <div class="row mb-1">
-              <div class="info-item col-4"><?php echo _("Hostname"); ?></div><div class="info-value col"><?php echo htmlspecialchars($hostname, ENT_QUOTES); ?></div>
-            </div>
-            <div class="row mb-1">
-              <div class="info-item col-4"><?php echo _("Pi Revision"); ?></div><div class="info-value col"><?php echo htmlspecialchars($revision, ENT_QUOTES); ?></div>
-            </div>
-            <div class="row mb-1">
-              <div class="info-item col-4"><?php echo _("OS"); ?></div><div class="info-value col"><?php echo htmlspecialchars($os, ENT_QUOTES); ?></div>
-            </div>
-            <div class="row mb-1">
-              <div class="info-item col-4"><?php echo _("Kernel"); ?></div><div class="info-value col"><?php echo htmlspecialchars($kernel, ENT_QUOTES); ?></div>
-            </div>
-            <div class="row mb-1">
-              <div class="info-item col-4"><?php echo _("Uptime"); ?></div><div class="info-value col"><?php echo htmlspecialchars($uptime, ENT_QUOTES); ?></div>
-	    </div>
-	    <div class="row mb-1">
-              <div class="info-item col-4"><?php echo _("System Time"); ?></div><div class="info-value col"><?php echo htmlspecialchars($systime, ENT_QUOTES); ?></div>
-            </div>
-          </div>
-        </div>
-      <div class="mb-1"><?php echo _("Memory Used"); ?></div>
-      <div class="progress mb-2" style="height: 20px;">
-        <div class="progress-bar bg-<?php echo htmlspecialchars($memused_status, ENT_QUOTES); ?>"
-            role="progressbar" aria-valuenow="<?php echo htmlspecialchars($memused, ENT_QUOTES); ?>" aria-valuemin="0" aria-valuemax="100"
-            style="width: <?php echo htmlspecialchars($memused, ENT_QUOTES); ?>%"><?php echo htmlspecialchars($memused, ENT_QUOTES); ?>%
-        </div>
+        </form>
       </div>
-      <div class="mb-1"><?php echo _("Storage Used"); ?></div>
-      <div class="progress mb-2" style="height: 20px;">
-        <div class="progress-bar bg-<?php echo htmlspecialchars($diskused_status, ENT_QUOTES); ?>"
-            role="progressbar" aria-valuenow="<?php echo htmlspecialchars($diskused, ENT_QUOTES); ?>" aria-valuemin="0" aria-valuemax="100"
-            style="width: <?php echo htmlspecialchars($diskused, ENT_QUOTES); ?>%"><?php echo htmlspecialchars($diskused, ENT_QUOTES); ?>%
+
+      <div class="d-flex flex-column mb-3">
+        <div class="row mb-1">
+          <div class="info-item col-4"><?php echo _("Hostname"); ?></div><div class="info-value col"><?php echo htmlspecialchars($hostname, ENT_QUOTES); ?></div>
         </div>
-      </div>
-      <div class="mb-1"><?php echo _("CPU Load"); ?></div>
-      <div class="progress mb-2" style="height: 20px;">
-        <div class="progress-bar bg-<?php echo htmlspecialchars($cpuload_status, ENT_QUOTES); ?>"
-            role="progressbar" aria-valuenow="<?php echo htmlspecialchars($cpuload, ENT_QUOTES); ?>" aria-valuemin="0" aria-valuemax="100"
-            style="width: <?php echo htmlspecialchars($cpuload, ENT_QUOTES); ?>%"><?php echo htmlspecialchars($cpuload, ENT_QUOTES); ?>%
+        <div class="row mb-1">
+          <div class="info-item col-4"><?php echo _("Pi Revision"); ?></div><div class="info-value col"><?php echo htmlspecialchars($revision, ENT_QUOTES); ?></div>
         </div>
-      </div>
-      <div class="mb-1"><?php echo _("CPU Temp"); ?></div>
-      <div class="progress mb-4" style="height: 20px;">
-        <div class="progress-bar bg-<?php echo htmlspecialchars($cputemp_status, ENT_QUOTES); ?>"
-            role="progressbar" aria-valuenow="<?php echo htmlspecialchars($cputemp, ENT_QUOTES); ?>" aria-valuemin="0" aria-valuemax="100"
-            style="width: <?php echo htmlspecialchars(($cputemp*1.2), ENT_QUOTES); ?>%"><?php echo htmlspecialchars($cputemp, ENT_QUOTES); ?>°C
+        <div class="row mb-1">
+          <div class="info-item col-4"><?php echo _("OS"); ?></div><div class="info-value col"><?php echo htmlspecialchars($os, ENT_QUOTES); ?></div>
+        </div>
+        <div class="row mb-1">
+          <div class="info-item col-4"><?php echo _("Kernel"); ?></div><div class="info-value col"><?php echo htmlspecialchars($kernel, ENT_QUOTES); ?></div>
+        </div>
+        <div class="row mb-1">
+          <div class="info-item col-4"><?php echo _("Uptime"); ?></div><div class="info-value col"><?php echo htmlspecialchars($uptime, ENT_QUOTES); ?></div>
+        </div>
+        <div class="row mb-1">
+          <div class="info-item col-4"><?php echo _("System Time"); ?></div><div class="info-value col"><?php echo htmlspecialchars($systime, ENT_QUOTES); ?></div>
         </div>
       </div>
 
-      <form action="system_info" method="POST">
-        <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
-        <div class="d-flex flex-wrap gap-2">
-          <?php if (!RASPI_MONITOR_ENABLED) : ?>
-              <input type="button" class="btn btn-warning" data-bs-toggle="modal" data-bs-target="#system-confirm-reboot" value="<?php echo _("Reboot"); ?>" />
-              <input type="button" class="btn btn-warning" data-bs-toggle="modal" data-bs-target="#system-confirm-shutdown" value="<?php echo _("Shutdown"); ?>" />
-          <?php endif ?>
-          <button type="button" onClick="window.location.reload();" class="btn btn-outline-primary"><i class="fas fa-sync-alt"></i> <?php echo _("Refresh") ?></a>
+      <div class="border rounded p-3">
+        <div class="d-flex justify-content-end mb-2">
+          <button type="button" onClick="window.location.reload();" class="btn btn-sm btn-outline-primary"><i class="fas fa-sync-alt"></i> <?php echo _("Refresh") ?></button>
         </div>
-      </form>
+        <div class="mb-1"><?php echo _("Memory Used"); ?></div>
+        <div class="progress progress-improved mb-2" style="height: 20px;" data-text="<?php echo htmlspecialchars($memused, ENT_QUOTES); ?>%">
+          <div class="progress-bar bg-<?php echo htmlspecialchars($memused_status, ENT_QUOTES); ?>"
+            role="progressbar"
+            aria-valuenow="<?php echo htmlspecialchars($memused, ENT_QUOTES); ?>"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            style="--progress: <?php echo htmlspecialchars($memused, ENT_QUOTES); ?>%"
+          >
+            <span><?php echo htmlspecialchars($memused, ENT_QUOTES); ?>%</span>
+          </div>
+        </div>
+        <div class="mb-1"><?php echo _("Storage Used"); ?></div>
+        <div class="progress progress-improved mb-2" style="height: 20px;" data-text="<?php echo htmlspecialchars($diskused, ENT_QUOTES); ?>%">
+          <div class="progress-bar bg-<?php echo htmlspecialchars($diskused_status, ENT_QUOTES); ?>"
+            role="progressbar"
+            aria-valuenow="<?php echo htmlspecialchars($diskused, ENT_QUOTES); ?>"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            style="--progress: <?php echo htmlspecialchars($diskused, ENT_QUOTES); ?>%"
+          >
+            <span><?php echo htmlspecialchars($diskused, ENT_QUOTES); ?>%</span>
+          </div>
+        </div>
+        <div class="mb-1"><?php echo _("CPU Load"); ?></div>
+        <div class="progress progress-improved mb-2" style="height: 20px;" data-text="<?php echo htmlspecialchars($cpuload, ENT_QUOTES); ?>%">
+          <div class="progress-bar bg-<?php echo htmlspecialchars($cpuload_status, ENT_QUOTES); ?>"
+            role="progressbar"
+            aria-valuenow="<?php echo htmlspecialchars($cpuload, ENT_QUOTES); ?>"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            style="--progress: <?php echo htmlspecialchars($cpuload, ENT_QUOTES); ?>%"
+          >
+            <span><?php echo htmlspecialchars($cpuload, ENT_QUOTES); ?>%</span>
+          </div>
+        </div>
+        <div class="mb-1"><?php echo _("CPU Temp"); ?></div>
+        <div class="progress progress-improved" style="height: 20px;" data-text="<?php echo htmlspecialchars($cputemp, ENT_QUOTES); ?>°C">
+          <div class="progress-bar bg-<?php echo htmlspecialchars($cputemp_status, ENT_QUOTES); ?>"
+            role="progressbar"
+            aria-valuenow="<?php echo htmlspecialchars($cputemp, ENT_QUOTES); ?>"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            style="--progress: <?php echo htmlspecialchars(($cputemp*1.2), ENT_QUOTES); ?>%"
+          >
+            <span><?php echo htmlspecialchars($cputemp, ENT_QUOTES); ?>°C</span>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/templates/system/basic.php
+++ b/templates/system/basic.php
@@ -32,23 +32,29 @@ include('includes/sysstats.php');
       </div>
 
       <div class="d-flex flex-column mb-3">
-        <div class="row mb-1">
-          <div class="info-item col-4"><?php echo _("Hostname"); ?></div><div class="info-value col"><?php echo htmlspecialchars($hostname, ENT_QUOTES); ?></div>
+        <div class="d-flex mb-1">
+          <div class="info-item"><?php echo _("Hostname"); ?></div>
+          <div class="info-value"><?php echo htmlspecialchars($hostname, ENT_QUOTES); ?></div>
         </div>
-        <div class="row mb-1">
-          <div class="info-item col-4"><?php echo _("Pi Revision"); ?></div><div class="info-value col"><?php echo htmlspecialchars($revision, ENT_QUOTES); ?></div>
+        <div class="d-flex mb-1">
+          <div class="info-item"><?php echo _("Pi Revision"); ?></div>
+          <div class="info-value"><?php echo htmlspecialchars($revision, ENT_QUOTES); ?></div>
         </div>
-        <div class="row mb-1">
-          <div class="info-item col-4"><?php echo _("OS"); ?></div><div class="info-value col"><?php echo htmlspecialchars($os, ENT_QUOTES); ?></div>
+        <div class="d-flex mb-1">
+          <div class="info-item"><?php echo _("OS"); ?></div>
+          <div class="info-value"><?php echo htmlspecialchars($os, ENT_QUOTES); ?></div>
         </div>
-        <div class="row mb-1">
-          <div class="info-item col-4"><?php echo _("Kernel"); ?></div><div class="info-value col"><?php echo htmlspecialchars($kernel, ENT_QUOTES); ?></div>
+        <div class="d-flex mb-1">
+          <div class="info-item"><?php echo _("Kernel"); ?></div>
+          <div class="info-value"><?php echo htmlspecialchars($kernel, ENT_QUOTES); ?></div>
         </div>
-        <div class="row mb-1">
-          <div class="info-item col-4"><?php echo _("Uptime"); ?></div><div class="info-value col"><?php echo htmlspecialchars($uptime, ENT_QUOTES); ?></div>
+        <div class="d-flex mb-1">
+          <div class="info-item"><?php echo _("Uptime"); ?></div>
+          <div class="info-value"><?php echo htmlspecialchars($uptime, ENT_QUOTES); ?></div>
         </div>
-        <div class="row mb-1">
-          <div class="info-item col-4"><?php echo _("System Time"); ?></div><div class="info-value col"><?php echo htmlspecialchars($systime, ENT_QUOTES); ?></div>
+        <div class="d-flex mb-1">
+          <div class="info-item"><?php echo _("System Time"); ?></div>
+          <div class="info-value"><?php echo htmlspecialchars($systime, ENT_QUOTES); ?></div>
         </div>
       </div>
 

--- a/templates/system/language.php
+++ b/templates/system/language.php
@@ -9,7 +9,6 @@
   </div>
   <div class="d-flex flex-wrap gap-2">
     <input type="submit" class="btn btn-outline-primary" name="SaveLanguage" value="<?php echo _("Save settings"); ?>" />
-    <button type="button" onClick="window.location.reload();" class="btn btn-outline-primary"><i class="fas fa-sync-alt"></i> <?php echo _("Refresh") ?></button>
   </div>
 </div>
 

--- a/templates/system/language.php
+++ b/templates/system/language.php
@@ -8,8 +8,8 @@
     </div>
   </div>
   <div class="d-flex flex-wrap gap-2">
-    <input type="submit" class="btn btn-outline btn-primary" name="SaveLanguage" value="<?php echo _("Save settings"); ?>" />
-    <button type="button" onClick="window.location.reload();" class="btn btn-outline btn-primary"><i class="fas fa-sync-alt"></i> <?php echo _("Refresh") ?></button>
+    <input type="submit" class="btn btn-outline-primary" name="SaveLanguage" value="<?php echo _("Save settings"); ?>" />
+    <button type="button" onClick="window.location.reload();" class="btn btn-outline-primary"><i class="fas fa-sync-alt"></i> <?php echo _("Refresh") ?></button>
   </div>
 </div>
 

--- a/templates/system/theme.php
+++ b/templates/system/theme.php
@@ -53,9 +53,8 @@
     </div>
     <div class="d-flex flex-wrap gap-2">
       <?php if (!RASPI_MONITOR_ENABLED) : ?>
-      <input type="submit" class="btn btn-outline-primary" name="savethemeSettings" value="<?php echo _("Save settings"); ?>" />
+        <input type="submit" class="btn btn-outline-primary" name="savethemeSettings" value="<?php echo _("Save settings"); ?>" />
       <?php endif; ?>
-      <button type="button" onClick="window.location.reload();" class="btn btn-outline-primary"><i class="fas fa-sync-alt"></i> <?php echo _("Refresh") ?></button>
     </div>
   </form>
 </div>

--- a/templates/system/theme.php
+++ b/templates/system/theme.php
@@ -53,9 +53,9 @@
     </div>
     <div class="d-flex flex-wrap gap-2">
       <?php if (!RASPI_MONITOR_ENABLED) : ?>
-      <input type="submit" class="btn btn-outline btn-primary" name="savethemeSettings" value="<?php echo _("Save settings"); ?>" />
+      <input type="submit" class="btn btn-outline-primary" name="savethemeSettings" value="<?php echo _("Save settings"); ?>" />
       <?php endif; ?>
-      <button type="button" onClick="window.location.reload();" class="btn btn-outline btn-primary"><i class="fas fa-sync-alt"></i> <?php echo _("Refresh") ?></button>
+      <button type="button" onClick="window.location.reload();" class="btn btn-outline-primary"><i class="fas fa-sync-alt"></i> <?php echo _("Refresh") ?></button>
     </div>
   </form>
 </div>

--- a/templates/torproxy.php
+++ b/templates/torproxy.php
@@ -97,7 +97,7 @@
                     </div>
                 </div>
 
-                <input type="submit" class="btn btn-outline btn-primary" name="SaveTORProxySettings" value="Save settings" />
+                <input type="submit" class="btn btn-outline-primary" name="SaveTORProxySettings" value="Save settings" />
                 <?php
                 if ($torproxystatus[0] == 0) {
                     echo '<input type="submit" class="btn btn-success" name="StartTOR" value="Start TOR" />' , PHP_EOL;

--- a/templates/wg/peers.php
+++ b/templates/wg/peers.php
@@ -21,7 +21,7 @@
         </div>
         <div class="input-group col-md-12">
           <input type="text" class="form-control" name="wg-peer" id="wg-peerpubkey" value="<?php echo htmlspecialchars($wg_peerpubkey, ENT_QUOTES); ?>" />
-          <div class="btn btn-outline-secondary rounded-end wg-keygen"><i class="fa-solid fa-wand-magic-sparkles"></i></div>
+          <button class="btn btn-light rounded-end wg-keygen"><i class="fa-solid fa-wand-magic-sparkles"></i></button>
           <span id="wg-peer-pubkey-status" class="input-group-addon check-hidden ms-2 mt-1"><i class="fas fa-check"></i></span>
         </div>
       </div>

--- a/templates/wireguard.php
+++ b/templates/wireguard.php
@@ -1,6 +1,6 @@
 <?php ob_start() ?>
   <?php if (!RASPI_MONITOR_ENABLED) : ?>
-    <input type="submit" class="btn btn-outline btn-primary" name="savewgsettings" value="<?php echo _("Save settings"); ?>">
+    <input type="submit" class="btn btn-outline-primary" name="savewgsettings" value="<?php echo _("Save settings"); ?>">
   <?php endif ?>
 <?php $buttons = ob_get_clean(); ob_end_clean() ?>
 


### PR DESCRIPTION
This PR continues the incremental updates/fixes/maintenance on a few things of the UI/UX.

- Login Redirects support hash tabs
- Add support for layered modals
  - Updates the z-index of the modal and overlays based on number of visible modals to cleanly stack
- Default to auto-dismiss alerts. Set value to 0 on settings page to disable.
  - This feels like what should be the default behavior to me. Agreed by a handful of users on the discord in the polls channel.
- Relocated/added refresh buttons to top of page for a more convienent and consistent experience
  - Removed refresh buttons from System#language and System#theme pages 
- Rework button style overrides to utilize bootstrap css variables for cleaner code and better, more consistent experience
- Slight redesign of the System#basic page
- Slight tweaks on login page
- Added js to close sidebar when the mobile overlay is clicked

## Insiders Todo
- Refresh buttons
  - Networking#devices
- Button classes