### PR TITLE
Feature: Live Form Submission

### DIFF
--- a/ajax/page/adblock.php
+++ b/ajax/page/adblock.php
@@ -1,0 +1,97 @@
+<?php
+require_once '../../includes/autoload.php';
+require_once '../../includes/CSRF.php';
+require_once '../../includes/session.php';
+require_once '../../includes/config.php';
+require_once '../../includes/authenticate.php';
+
+$liveForm = new \RaspAP\UI\LiveForm();
+$liveForm->initAjax();
+$liveForm->sendStartMessage();
+
+if (RASPI_MONITOR_ENABLED) {
+    $liveForm->sendUpdateMessage('RaspAP Monitor Mode Enabled', 100);
+    $liveForm->saveStatusMessage('RaspAP Monitor Mode Enabled', 'warning');
+    $liveForm->sendCompleteMessage();
+}
+
+if (isset($_POST['saveadblocksettings'])) {
+    if ($_POST['adblock-enable'] == "1") {
+        $liveForm->sendUpdateMessage('Enabling Blocklists', 30);
+        $config = 'conf-file=' .RASPI_ADBLOCK_LISTPATH .'domains.txt'.PHP_EOL;
+        $config.= 'addn-hosts=' .RASPI_ADBLOCK_LISTPATH .'hostnames.txt'.PHP_EOL;
+    } elseif ($_POST['adblock-enable'] == "0") {
+        $liveForm->sendUpdateMessage('Disabling Blocklists', 30);
+        $config = null;
+    }
+
+    if ($_POST['adblock-custom-enable'] == "1") {
+        $liveForm->sendUpdateMessage('Enabling Custom Blocklists', 60);
+        // validate custom hosts input
+        $lines = preg_split('/\r\n|\n|\r/', trim($_POST['adblock-custom-hosts']));
+        if (!in_array("", $lines, true)) {
+            foreach ($lines as $line) {
+                $ip_host = preg_split('/\s+/', $line);
+                $index++;
+                if (!filter_var($ip_host[0], FILTER_VALIDATE_IP)) {
+                    $liveForm->sendUpdateMessage('Invalid custom IP address found on line '.$index);
+                    $errors .= _('Invalid custom IP address found on line '.$index);
+                    break;
+                }
+                if (!validate_host($ip_host[1])) {
+                    $liveForm->sendUpdateMessage('Invalid custom host found on line '.$index);
+                    $errors .= _('Invalid custom host found on line '.$index);
+                    break;
+                }
+            }
+        }
+        file_put_contents("/tmp/dnsmasq_custom", $_POST['adblock-custom-hosts'].PHP_EOL);
+        system("sudo cp /tmp/dnsmasq_custom " .RASPI_ADBLOCK_LISTPATH .'custom.txt', $return);
+        $config.= 'addn-hosts=' .RASPI_ADBLOCK_LISTPATH .'custom.txt'.PHP_EOL;
+    }
+
+    if (empty($errors)) {
+        file_put_contents("/tmp/dnsmasqdata", $config);
+        system('sudo cp /tmp/dnsmasqdata '.RASPI_ADBLOCK_CONFIG, $return);
+        if ($return == 0) {
+            $liveForm->sendUpdateMessage('Successfully updated Adblock configuration', 90);
+            $liveForm->saveStatusMessage('Successfully updated Adblock configuration', 'success', true);
+            $liveForm->sendCompleteMessage();
+        } else {
+            $liveForm->sendUpdateMessage('Failed to update Adblock configuration', 90);
+            $liveForm->saveStatusMessage('Failed to update Adblock configuration', 'danger', true);
+            $liveForm->sendFailedMessage();
+        }
+    } else {
+        $liveForm->saveStatusMessage('Adblock configuration failed to be updated. '.$errors, 'danger', true);
+        $liveForm->sendFailedMessage();
+    }
+} elseif (isset($_POST['restartadblock']) || isset($_POST['startadblock'])) {
+    if (isset($_POST['restartadblock'])) {
+        $liveForm->sendUpdateMessage('Restarting Adblock', 50);
+    } elseif (isset($_POST['startadblock'])) {
+        $liveForm->sendUpdateMessage('Starting Adblock', 50);
+    }
+
+    exec('sudo /bin/systemctl restart dnsmasq.service', $dnsmasq, $return);
+    if ($return == 0) {
+        if (isset($_POST['restartadblock'])) {
+            $liveForm->saveStatusMessage('Successfully Restarted Adblock', 'success');
+            $liveForm->sendCompleteMessage();
+        } elseif (isset($_POST['startadblock'])) {
+            $liveForm->saveStatusMessage('Successfully Started Adblock', 'success');
+            $liveForm->sendCompleteMessage();
+        }
+    } else {
+        if (isset($_POST['restartadblock'])) {
+            $liveForm->saveStatusMessage('Failed to Restart Adblock', 'danger');
+            $liveForm->sendFailedMessage();
+        } elseif (isset($_POST['startadblock'])) {
+            $liveForm->saveStatusMessage('Failed to Start Adblock', 'danger');
+            $liveForm->sendFailedMessage();
+        }
+    }
+}
+
+$liveForm->saveStatusMessage('No Instructions to Complete', 'warning');
+$liveForm->sendCompleteMessage();

--- a/ajax/page/adblock.php
+++ b/ajax/page/adblock.php
@@ -10,23 +10,23 @@ $liveForm->initAjax();
 $liveForm->sendStartMessage();
 
 if (RASPI_MONITOR_ENABLED) {
-    $liveForm->sendUpdateMessage('RaspAP Monitor Mode Enabled', 100);
-    $liveForm->saveStatusMessage('RaspAP Monitor Mode Enabled', 'warning');
+    $liveForm->sendUpdateMessage(_('RaspAP Monitor Mode Enabled'), 100);
+    $liveForm->saveStatusMessage(_('RaspAP Monitor Mode Enabled'), 'warning');
     $liveForm->sendCompleteMessage();
 }
 
 if (isset($_POST['saveadblocksettings'])) {
     if ($_POST['adblock-enable'] == "1") {
-        $liveForm->sendUpdateMessage('Enabling Blocklists', 30);
+        $liveForm->sendUpdateMessage(_('Enabling Blocklists'), 30);
         $config = 'conf-file=' .RASPI_ADBLOCK_LISTPATH .'domains.txt'.PHP_EOL;
         $config.= 'addn-hosts=' .RASPI_ADBLOCK_LISTPATH .'hostnames.txt'.PHP_EOL;
     } elseif ($_POST['adblock-enable'] == "0") {
-        $liveForm->sendUpdateMessage('Disabling Blocklists', 30);
+        $liveForm->sendUpdateMessage(_('Disabling Blocklists'), 30);
         $config = null;
     }
 
     if ($_POST['adblock-custom-enable'] == "1") {
-        $liveForm->sendUpdateMessage('Enabling Custom Blocklists', 60);
+        $liveForm->sendUpdateMessage(_('Enabling Custom Blocklists'), 60);
         // validate custom hosts input
         $lines = preg_split('/\r\n|\n|\r/', trim($_POST['adblock-custom-hosts']));
         if (!in_array("", $lines, true)) {
@@ -34,13 +34,13 @@ if (isset($_POST['saveadblocksettings'])) {
                 $ip_host = preg_split('/\s+/', $line);
                 $index++;
                 if (!filter_var($ip_host[0], FILTER_VALIDATE_IP)) {
-                    $liveForm->sendUpdateMessage('Invalid custom IP address found on line '.$index);
-                    $errors .= _('Invalid custom IP address found on line '.$index);
+                    $liveForm->sendUpdateMessage(sprintf(_('Invalid custom IP address found on line %d'), $index));
+                    $errors = true;
                     break;
                 }
                 if (!validate_host($ip_host[1])) {
-                    $liveForm->sendUpdateMessage('Invalid custom host found on line '.$index);
-                    $errors .= _('Invalid custom host found on line '.$index);
+                    $liveForm->sendUpdateMessage(sprintf(_('Invalid custom host found on line %d'), $index));
+                    $errors = true;
                     break;
                 }
             }
@@ -54,44 +54,44 @@ if (isset($_POST['saveadblocksettings'])) {
         file_put_contents("/tmp/dnsmasqdata", $config);
         system('sudo cp /tmp/dnsmasqdata '.RASPI_ADBLOCK_CONFIG, $return);
         if ($return == 0) {
-            $liveForm->sendUpdateMessage('Successfully updated Adblock configuration', 90);
-            $liveForm->saveStatusMessage('Successfully updated Adblock configuration', 'success', true);
+            $liveForm->sendUpdateMessage(_('Successfully updated Adblock configuration'), 90);
+            $liveForm->saveStatusMessage(_('Successfully updated Adblock configuration'), 'success', true);
             $liveForm->sendCompleteMessage();
         } else {
-            $liveForm->sendUpdateMessage('Failed to update Adblock configuration', 90);
-            $liveForm->saveStatusMessage('Failed to update Adblock configuration', 'danger', true);
+            $liveForm->sendUpdateMessage(_('Failed to update Adblock configuration'), 90);
+            $liveForm->saveStatusMessage(_('Failed to update Adblock configuration'), 'danger', true);
             $liveForm->sendFailedMessage();
         }
     } else {
-        $liveForm->saveStatusMessage('Adblock configuration failed to be updated. '.$errors, 'danger', true);
+        $liveForm->saveStatusMessage(_('Adblock configuration failed to be updated'), 'danger', true);
         $liveForm->sendFailedMessage();
     }
 } elseif (isset($_POST['restartadblock']) || isset($_POST['startadblock'])) {
     if (isset($_POST['restartadblock'])) {
-        $liveForm->sendUpdateMessage('Restarting Adblock', 50);
+        $liveForm->sendUpdateMessage(_('Restarting Adblock'), 50);
     } elseif (isset($_POST['startadblock'])) {
-        $liveForm->sendUpdateMessage('Starting Adblock', 50);
+        $liveForm->sendUpdateMessage(_('Starting Adblock'), 50);
     }
 
     exec('sudo /bin/systemctl restart dnsmasq.service', $dnsmasq, $return);
     if ($return == 0) {
         if (isset($_POST['restartadblock'])) {
-            $liveForm->saveStatusMessage('Successfully Restarted Adblock', 'success');
+            $liveForm->saveStatusMessage(_('Successfully Restarted Adblock'), 'success');
             $liveForm->sendCompleteMessage();
         } elseif (isset($_POST['startadblock'])) {
-            $liveForm->saveStatusMessage('Successfully Started Adblock', 'success');
+            $liveForm->saveStatusMessage(_('Successfully Started Adblock'), 'success');
             $liveForm->sendCompleteMessage();
         }
     } else {
         if (isset($_POST['restartadblock'])) {
-            $liveForm->saveStatusMessage('Failed to Restart Adblock', 'danger');
+            $liveForm->saveStatusMessage(_('Failed to Restart Adblock'), 'danger');
             $liveForm->sendFailedMessage();
         } elseif (isset($_POST['startadblock'])) {
-            $liveForm->saveStatusMessage('Failed to Start Adblock', 'danger');
+            $liveForm->saveStatusMessage(_('Failed to Start Adblock'), 'danger');
             $liveForm->sendFailedMessage();
         }
     }
 }
 
-$liveForm->saveStatusMessage('No Instructions to Complete', 'warning');
+$liveForm->saveStatusMessage(_('No Instructions to Complete'), 'warning');
 $liveForm->sendCompleteMessage();

--- a/ajax/page/adblock.php
+++ b/ajax/page/adblock.php
@@ -9,6 +9,8 @@ $liveForm = new \RaspAP\UI\LiveForm();
 $liveForm->initAjax();
 $liveForm->sendStartMessage();
 
+try {
+
 if (RASPI_MONITOR_ENABLED) {
     $liveForm->sendUpdateMessage(_('RaspAP Monitor Mode Enabled'), 100);
     $liveForm->saveStatusMessage(_('RaspAP Monitor Mode Enabled'), 'warning');
@@ -95,3 +97,9 @@ if (isset($_POST['saveadblocksettings'])) {
 
 $liveForm->saveStatusMessage(_('No Instructions to Complete'), 'warning');
 $liveForm->sendCompleteMessage();
+
+} catch (\Throwable $e) {
+    $liveForm->sendUpdateMessage(sprintf(_('An error occurred: %s'), $e->getMessage()), 100);
+    $liveForm->saveStatusMessage(_('An error occurred'), 'danger', true);
+    $liveForm->sendFailedMessage();
+}

--- a/ajax/page/client.php
+++ b/ajax/page/client.php
@@ -4,14 +4,13 @@ require_once '../../includes/CSRF.php';
 require_once '../../includes/session.php';
 require_once '../../includes/config.php';
 require_once '../../includes/authenticate.php';
-
-use RaspAP\Networking\Hotspot\WiFiManager;
+require_once '../../includes/functions.php';
 
 $liveForm = new \RaspAP\UI\LiveForm();
 $liveForm->initAjax();
 $liveForm->sendStartMessage();
 
-$wifi = new WiFiManager();
+$wifi = new \RaspAP\Networking\Hotspot\WiFiManager();
 
 $clientInterface = $_SESSION['wifi_client_interface'];
 

--- a/ajax/page/client.php
+++ b/ajax/page/client.php
@@ -10,6 +10,8 @@ $liveForm = new \RaspAP\UI\LiveForm();
 $liveForm->initAjax();
 $liveForm->sendStartMessage();
 
+try {
+
 $wifi = new \RaspAP\Networking\Hotspot\WiFiManager();
 
 $clientInterface = $_SESSION['wifi_client_interface'];
@@ -112,3 +114,9 @@ if (isset($_POST['wifiClientInterface'])) {
 
 $liveForm->saveStatusMessage(_('No Instructions to Complete'), 'warning');
 $liveForm->sendCompleteMessage();
+
+} catch (\Throwable $e) {
+    $liveForm->sendUpdateMessage(sprintf(_('An error occurred: %s'), $e->getMessage()), 100);
+    $liveForm->saveStatusMessage(_('An error occurred'), 'danger', true);
+    $liveForm->sendFailedMessage();
+}

--- a/ajax/page/client.php
+++ b/ajax/page/client.php
@@ -1,0 +1,115 @@
+<?php
+require_once '../../includes/autoload.php';
+require_once '../../includes/CSRF.php';
+require_once '../../includes/session.php';
+require_once '../../includes/config.php';
+require_once '../../includes/authenticate.php';
+
+use RaspAP\Networking\Hotspot\WiFiManager;
+
+$liveForm = new \RaspAP\UI\LiveForm();
+$liveForm->initAjax();
+$liveForm->sendStartMessage();
+
+$wifi = new WiFiManager();
+
+$clientInterface = $_SESSION['wifi_client_interface'];
+
+if (isset($_POST['wifiClientInterface'])) {
+    $saveInterfaceStatus = $wifi->getWifiInterface();
+    if ($saveInterfaceStatus !== null) {
+        $liveForm->sendUpdateMessage($saveInterfaceStatus['message'], 10);
+        $liveForm->saveStatusMessage($saveInterfaceStatus['message'], $saveInterfaceStatus['status'], true);
+        if ($saveInterfaceStatus['status'] === 'danger') {
+            $liveForm->sendFailedMessage();
+        } else {
+            $liveForm->sendCompleteMessage();
+        }
+    }
+} elseif (isset($_POST['connect'])) {
+    $liveForm->sendUpdateMessage(_('Attempting to connect to network'), 40);
+    $netid = intval($_POST['connect']);
+
+    if ($wifi->connectToNetwork($clientInterface, $netid)) {
+        $liveForm->sendUpdateMessage(_('Connected to network successfully'), 80);
+        $liveForm->saveStatusMessage(_('Connected to network successfully'), 'success', true);
+        $liveForm->sendCompleteMessage();
+    } else {
+        $liveForm->sendUpdateMessage(_('Failed to connect to network'), 80);
+        $liveForm->saveStatusMessage(_('WPA command line client returned failure. Check your adapter.'), 'danger', true);
+        $liveForm->sendFailedMessage();
+    }
+} elseif (isset($_POST['wpa_reinit'])) {
+    $liveForm->sendUpdateMessage(_('Attempting to reinitialize wpa_supplicant'), 40);
+    $force_remove = true;
+    $result = $wifi->reinitializeWPA($force_remove);
+    if (str_contains($result, 'OK')) {
+        $liveForm->sendUpdateMessage(_('wpa_supplicant reinitialized successfully'), 80);
+        $liveForm->saveStatusMessage(_('wpa_supplicant reinitialized successfully'), 'success', true);
+        $liveForm->sendCompleteMessage();
+    } else {
+        error_log("wpa_supplicant reinit result: " . var_export($result, true));
+        $liveForm->sendUpdateMessage(_('Failed to reinitialize wpa_supplicant:'), 80);
+        $liveForm->sendUpdateMessage($result, 80);
+        $liveForm->saveStatusMessage(_('Failed to reinitialize wpa_supplicant'), 'danger', true);
+        $liveForm->sendFailedMessage();
+    }
+} elseif (isset($_POST['client_settings'])) {
+    $liveForm->sendUpdateMessage(_("Updating network settings"), 20);
+    $tmp_networks = $networks;
+
+    foreach (array_keys($_POST) as $post) {
+
+        if (preg_match('/delete(\d+)/', $post, $post_match)) {
+            $network = $tmp_networks[$_POST['ssid' . $post_match[1]]];
+            $netid = $network['index'];
+            $liveForm->sendUpdateMessage(sprintf(_('Deleting network: %s'), $network['ssid']));
+            $wifi->deleteNetwork($clientInterface, $netid);
+            unset($tmp_networks[$_POST['ssid' . $post_match[1]]]);
+        } elseif (preg_match('/disconnect(\d+)/', $post, $post_match)) {
+            $network = $tmp_networks[$_POST['ssid' . $post_match[1]]];
+            $netid = $network['index'];
+            $liveForm->sendUpdateMessage(sprintf(_('Disconnecting from network: %s'), $network['ssid']));
+            $wifi->disconnectNetwork($clientInterface, $netid);
+        } elseif (preg_match('/update(\d+)/', $post, $post_match)) {
+            // NB, multiple protocols are separated with a forward slash ('/')
+            $protocol = $_POST['protocol' . $post_match[1]] === $wifi::SECURITY_OPEN ? $wifi::SECURITY_OPEN : 'WPA';
+            $tmp_networks[$_POST['ssid' . $post_match[1]]] = array(
+            'protocol' => $protocol,
+            'passphrase' => $_POST['passphrase' . $post_match[1]] ?? '',
+            'configured' => true
+            );
+            if (array_key_exists('priority' . $post_match[1], $_POST) && $_POST['priority' . $post_match[1]] != '') {
+                $tmp_networks[$_POST['ssid' . $post_match[1]]]['priority'] = $_POST['priority' . $post_match[1]];
+            }
+            $network = $tmp_networks[$_POST['ssid' . $post_match[1]]];
+
+            $ssid = $_POST['ssid' . $post_match[1]];
+            $passphrase = $_POST['passphrase' . $post_match[1]] ?? '';
+
+            $liveForm->sendUpdateMessage(sprintf(_('Updating network: %s'), $ssid));
+            $netid = $wifi->updateNetwork($clientInterface, $ssid, $passphrase, $protocol);
+            if ($netid === null) {
+                $liveForm->sendUpdateMessage(sprintf(_('Unable to add network with WPA command line client: %s'), $ssid));
+            }
+        }
+    }
+
+    $liveForm->sendUpdateMessage(_('Writing network settings'), 60);
+    $result = $wifi->writeWpaSupplicant($tmp_networks, $clientInterface);
+
+    if ($result['success']) {
+        $liveForm->sendUpdateMessage(_('Network settings saved successfully'), 80);
+        $liveForm->sendUpdateMessage($result['message']);
+        $liveForm->saveStatusMessage(_('Network settings saved successfully'), 'success', true);
+        $liveForm->sendCompleteMessage();
+    } else {
+        $liveForm->sendUpdateMessage(_('Failed to save network settings'), 80);
+        $liveForm->sendUpdateMessage($result['message']);
+        $liveForm->saveStatusMessage(_('Failed to save network settings'), 'danger', true);
+        $liveForm->sendFailedMessage();
+    }
+}
+
+$liveForm->saveStatusMessage(_('No Instructions to Complete'), 'warning');
+$liveForm->sendCompleteMessage();

--- a/ajax/page/dhcpd.php
+++ b/ajax/page/dhcpd.php
@@ -4,6 +4,7 @@ require_once '../../includes/CSRF.php';
 require_once '../../includes/session.php';
 require_once '../../includes/config.php';
 require_once '../../includes/authenticate.php';
+require_once '../../includes/functions.php';
 
 $liveForm = new \RaspAP\UI\LiveForm();
 $liveForm->initAjax();

--- a/ajax/page/dhcpd.php
+++ b/ajax/page/dhcpd.php
@@ -1,0 +1,138 @@
+<?php
+require_once '../../includes/autoload.php';
+require_once '../../includes/CSRF.php';
+require_once '../../includes/session.php';
+require_once '../../includes/config.php';
+require_once '../../includes/authenticate.php';
+
+$liveForm = new \RaspAP\UI\LiveForm();
+$liveForm->initAjax();
+$liveForm->sendStartMessage();
+
+if (RASPI_MONITOR_ENABLED) {
+    $liveForm->sendUpdateMessage(_('RaspAP Monitor Mode Enabled'), 100);
+    $liveForm->saveStatusMessage(_('RaspAP Monitor Mode Enabled'), 'warning');
+    $liveForm->sendCompleteMessage();
+}
+
+if (isset($_POST['savedhcpdsettings'])) {
+    $status = new \RaspAP\UI\LiveFormStatusMessage($liveForm);
+    $dhcpcd = new \RaspAP\Networking\Hotspot\DhcpcdManager();
+    $dnsmasq = new \RaspAP\Networking\Hotspot\DnsmasqManager();
+    $iface = $_POST['interface'];
+
+    if (!isset($_POST['dhcp-iface']) && file_exists(RASPI_DNSMASQ_PREFIX.$iface.'.conf')) {
+        $liveForm->sendUpdateMessage(sprintf(_('Removing DHCP Configuration for %s'), $iface), 50);
+
+        // remove dhcp + dnsmasq configs for selected interface
+        $return = $dhcpcd->remove($iface, $status);
+        $return = $dnsmasq->remove($iface, $status);
+    } else {
+        $liveForm->sendUpdateMessage(_('Validating DHCP Configuration'), 10);
+        $errors = $dhcpcd->validate($_POST);
+        if (empty($errors)) {
+            $liveForm->sendUpdateMessage(sprintf(_('Saving DHCP Configuration for %s'), $iface), 40);
+            $dhcp_cfg = $dhcpcd->buildConfigEx($iface, $_POST, $status);
+            $dhcpcd->saveConfig($dhcp_cfg, $iface, $status);
+            $liveForm->sendUpdateMessage(_('DHCP Configuration Saved'), 50);
+        } else {
+            $liveForm->sendUpdateMessage(_('DHCP Configuration Invalid with the following errors:'), 70);
+            foreach ($errors as $error) {
+                $liveForm->sendUpdateMessage($error);
+            }
+            $liveForm->saveStatusMessage(_('DHCP Configuration Invalid'), 'danger', true);
+            $liveForm->sendFailedMessage();
+        }
+
+        // dnsmasq
+        if (($_POST['dhcp-iface'] == "1") || (isset($_POST['mac']))) {
+            $liveForm->sendUpdateMessage(_('Validating dnsmasq Configuration'), 60);
+            $errors = $dnsmasq->validate($_POST);
+            if (empty($errors)) {
+                $liveForm->sendUpdateMessage(sprintf(_('Building dnsmasq Configuration for %s'), $iface), 70);
+                $config = $dnsmasq->buildConfigEx($iface, $_POST);
+                $liveForm->sendUpdateMessage(sprintf(_('Saving dnsmasq Configuration for %s'), $iface));
+                $return = $dnsmasq->saveConfig($config, $iface);
+
+                $liveForm->sendUpdateMessage(_('Building default dnsmasq Configuration'), 80);
+                $config = $dnsmasq->buildDefault($_POST);
+                $liveForm->sendUpdateMessage(_('Saving default dnsmasq Configuration'));
+                $return = $dnsmasq->saveConfigDefault($config);
+            } else {
+                $liveForm->sendUpdateMessage(_('DNSMASQ Configuration Invalid with the following errors:'), 70);
+                foreach ($errors as $error) {
+                    $liveForm->sendUpdateMessage($error);
+                }
+                $liveForm->saveStatusMessage(_('DNSMASQ Configuration Invalid'), 'danger', true);
+                $liveForm->sendFailedMessage();
+            }
+        }
+    }
+
+    $liveForm->sendUpdateMessage(_('DHCP Configuration Saved'), 90);
+    $liveForm->saveStatusMessage(_('DHCP Configuration Saved'), 'success', true);
+    $liveForm->sendCompleteMessage();
+} elseif (isset($_POST['startdhcpd']) || isset($_POST['stopdhcpd']) || isset($_POST['restartdhcpd'])) {
+    $liveForm->sendUpdateMessage(_('Checking current status'), 30);
+    exec('pidof dnsmasq | wc -l', $dnsmasq);
+    $dnsmasq_state = ($dnsmasq[0] > 0);
+
+    if (isset($_POST['startdhcpd'])) {
+        $liveForm->sendUpdateMessage(_('Starting DHCP Service'), 50);
+        if ($dnsmasq_state) {
+            $liveForm->sendUpdateMessage(_('DNSMASQ is already running'), 90);
+            $liveForm->saveStatusMessage(_('DNSMASQ is already running'), 'info', true);
+            $liveForm->sendCompleteMessage();
+        } else {
+            exec('sudo /bin/systemctl start dnsmasq.service', $dnsmasq, $return);
+            if ($return == 0) {
+                $liveForm->sendUpdateMessage(_('Successfully started dnsmasq'), 90);
+                $liveForm->saveStatusMessage(_('Successfully started dnsmasq'), 'success', true);
+                $liveForm->sendCompleteMessage();
+            } else {
+                $liveForm->sendUpdateMessage(_('Failed to start dnsmasq'), 90);
+                $liveForm->saveStatusMessage(_('Failed to start dnsmasq'), 'danger', true);
+                $liveForm->sendFailedMessage();
+            }
+        }
+    } elseif (isset($_POST['stopdhcpd'])) {
+        $liveForm->sendUpdateMessage(_('Stopping DHCP Service'), 50);
+        if ($dnsmasq_state) {
+            exec('sudo /bin/systemctl stop dnsmasq.service', $dnsmasq, $return);
+            if ($return == 0) {
+                $liveForm->sendUpdateMessage(_('Successfully stopped dnsmasq'), 90);
+                $liveForm->saveStatusMessage(_('Successfully stopped dnsmasq'), 'success', true);
+                $liveForm->sendCompleteMessage();
+            } else {
+                $liveForm->sendUpdateMessage(_('Failed to stop dnsmasq'), 90);
+                $liveForm->saveStatusMessage(_('Failed to stop dnsmasq'), 'danger', true);
+                $liveForm->sendFailedMessage();
+            }
+        } else {
+            $liveForm->sendUpdateMessage(_('DNSMASQ is already stopped'), 90);
+            $liveForm->saveStatusMessage(_('DNSMASQ is already stopped'), 'info', true);
+            $liveForm->sendCompleteMessage();
+        }
+    } elseif (isset($_POST['restartdhcpd'])) {
+        $liveForm->sendUpdateMessage(_('Restarting DHCP Service'), 50);
+        if ($dnsmasq_state) {
+            exec('sudo /bin/systemctl restart dnsmasq.service', $dnsmasq, $return);
+            if ($return == 0) {
+                $liveForm->sendUpdateMessage(_('Successfully restarted dnsmasq'), 90);
+                $liveForm->saveStatusMessage(_('Successfully restarted dnsmasq'), 'success', true);
+                $liveForm->sendCompleteMessage();
+            } else {
+                $liveForm->sendUpdateMessage(_('Failed to restart dnsmasq'), 90);
+                $liveForm->saveStatusMessage(_('Failed to restart dnsmasq'), 'danger', true);
+                $liveForm->sendFailedMessage();
+            }
+        } else {
+            $liveForm->sendUpdateMessage(_('DNSMASQ is already stopped'), 90);
+            $liveForm->saveStatusMessage(_('DNSMASQ is already stopped'), 'info', true);
+            $liveForm->sendCompleteMessage();
+        }
+    }
+}
+
+$liveForm->saveStatusMessage(_('No Instructions to Complete'), 'warning');
+$liveForm->sendCompleteMessage();

--- a/ajax/page/dhcpd.php
+++ b/ajax/page/dhcpd.php
@@ -10,6 +10,8 @@ $liveForm = new \RaspAP\UI\LiveForm();
 $liveForm->initAjax();
 $liveForm->sendStartMessage();
 
+try {
+
 if (RASPI_MONITOR_ENABLED) {
     $liveForm->sendUpdateMessage(_('RaspAP Monitor Mode Enabled'), 100);
     $liveForm->saveStatusMessage(_('RaspAP Monitor Mode Enabled'), 'warning');
@@ -137,3 +139,9 @@ if (isset($_POST['savedhcpdsettings'])) {
 
 $liveForm->saveStatusMessage(_('No Instructions to Complete'), 'warning');
 $liveForm->sendCompleteMessage();
+
+} catch (\Throwable $e) {
+    $liveForm->sendUpdateMessage(sprintf(_('An error occurred: %s'), $e->getMessage()), 100);
+    $liveForm->saveStatusMessage(_('An error occurred'), 'danger', true);
+    $liveForm->sendFailedMessage();
+}

--- a/ajax/page/hostapd.php
+++ b/ajax/page/hostapd.php
@@ -1,0 +1,143 @@
+<?php
+require_once '../../includes/autoload.php';
+require_once '../../includes/CSRF.php';
+require_once '../../includes/session.php';
+require_once '../../includes/config.php';
+require_once '../../includes/authenticate.php';
+require_once '../../includes/functions.php';
+
+$liveForm = new \RaspAP\UI\LiveForm();
+$liveForm->initAjax();
+$liveForm->sendStartMessage();
+
+try {
+
+if (RASPI_MONITOR_ENABLED) {
+    $liveForm->sendUpdateMessage(_('RaspAP Monitor Mode Enabled'), 100);
+    $liveForm->saveStatusMessage(_('RaspAP Monitor Mode Enabled'), 'warning');
+    $liveForm->sendCompleteMessage();
+}
+
+$hostapd = new \RaspAP\Networking\Hotspot\HostapdManager();
+$hotspot = new \RaspAP\Networking\Hotspot\HotspotService();
+$status = new \RaspAP\UI\LiveFormStatusMessage($liveForm);
+
+if (isset($_POST['SaveHostAPDSettings'])) {
+    $liveForm->sendUpdateMessage(_('Saving Hotspot settings'), 20);
+
+    $interface = $_POST['interface'];
+    $arrSecurity = $hotspot->getSecurityModes();
+    $arrEncType = $hotspot->getEncTypes();
+    $arr80211Standard = $hotspot->get80211Standards();
+    $ifaces = $hotspot->getInterfaces();
+    $reg_domain = $hotspot->getRegDomain();
+
+    $result = $hotspot->saveSettings(
+        $_POST,
+        $arrSecurity,
+        $arrEncType,
+        $arr80211Standard,
+        $ifaces,
+        $reg_domain,
+        $status
+    );
+
+     // process txpower user input
+    if (isset($_POST['txpower'])) {
+        if ($_POST['txpower'] != 'auto') {
+            $txpower = intval($_POST['txpower']);
+            $hotspot->maybeSetTxPower($interface, $txpower, $status);
+        } elseif ($_POST['txpower'] == 'auto') {
+            $hotspot->maybeSetTxPower($interface, 'auto', $status);
+        }
+    }
+
+    $liveForm->sendUpdateMessage(_('Saved Hotspot settings'), 90);
+    $liveForm->saveStatusMessage(_('Successfully saved Hotspot settings'), 'success', true);
+    $liveForm->sendCompleteMessage();
+} elseif (isset($_POST['StartHotspot']) || isset($_POST['RestartHotspot']) || isset($_POST['StopHotspot'])) {
+    $arrHostapdConf = $hotspot->getHostapdIni();
+    $interface = $_SESSION['ap_interface'];
+    $isDualAP = isset($arrHostapdConf['DualAPEnable']) && $arrHostapdConf['DualAPEnable'] == 1;
+
+    // check if hotspot is already running
+    // $hostapdstatus = $system->hostapdStatus();
+    // $serviceStatus = $hostapdstatus[0] == 0 ? "down" : "up";
+
+    if (isset($_POST['StartHotspot']) || isset($_POST['RestartHotspot'])) {
+        $liveForm->sendUpdateMessage(_('Attempting to start hotspot'), 30);
+
+        if ($arrHostapdConf['BridgedEnable'] == 1) {
+            $liveForm->sendUpdateMessage(_('Starting in bridged mode'), 40);
+            
+            exec('sudo '.RASPI_CONFIG.'/hostapd/servicestart.sh --interface br0 --seconds 1', $return);
+        } elseif ($arrHostapdConf['WifiAPEnable'] == 1) {
+            $liveForm->sendUpdateMessage(_('Starting in WiFi AP mode'), 40);
+
+            exec('sudo '.RASPI_CONFIG.'/hostapd/servicestart.sh --interface uap0 --seconds 1', $return);
+        } elseif ($isDualAP && $hostapd->countHostapdConfigs() < 2) {
+            $liveForm->sendUpdateMessage('Dual AP mode requires at least 2 hostapd configurations');
+            $liveForm->saveStatusMessage('Dual AP mode requires at least 2 hostapd configurations', 'danger');
+            $liveForm->sendFailedMessage();
+        } else {
+            $liveForm->sendUpdateMessage(_('Starting in standard mode'), 40);
+
+            // systemctl expects a unit name like raspap-network-activity@wlan0.service
+            $iface_nonescaped = $interface;
+            if (preg_match('/^[a-zA-Z0-9_-]+$/', $iface_nonescaped)) { // validate interface name
+                exec('sudo '.RASPI_CONFIG.'/hostapd/servicestart.sh --interface ' .$iface_nonescaped. ' --seconds 1', $return);
+            } else {
+                $liveForm->sendUpdateMessage(sprintf(_('Invalid network interface: %s'), $iface_nonescaped), 50);
+                $liveForm->saveStatusMessage(_('Invalid network interface'), 'danger');
+                $liveForm->sendFailedMessage();
+            }
+        }
+
+        foreach ($return as $line) {
+            $liveForm->sendUpdateMessage($line);
+        }
+
+        $liveForm->sendUpdateMessage(isset($_POST['RestartHotspot']) ? _('Hotspot Restarted') : _('Hotspot Started'), 90);
+        $liveForm->saveStatusMessage(isset($_POST['RestartHotspot']) ? _('Hotspot Restarted') : _('Hotspot Started'), 'success', true);
+        $liveForm->sendCompleteMessage();
+    } elseif (isset($_POST['StopHotspot'])) {
+        $liveForm->sendUpdateMessage(_('Attempting to stop hotspot'), 30);
+
+        if ($isDualAP) {
+            $liveForm->sendUpdateMessage(_('Stopping Hotspot in Dual AP mode'), 40);
+            // stop all hostapd@*.service units
+            exec('find /etc/hostapd -name "hostapd-*.conf"', $confFiles);
+            foreach ($confFiles as $conf) {
+                if (preg_match('/hostapd-([a-zA-Z0-9]+)\.conf$/', $conf, $matches)) {
+                    $iface = $matches[1];
+                    $cmd = escapeshellcmd("sudo systemctl stop hostapd@{$iface}.service");
+                    exec($cmd, $output);
+                    $liveForm->sendUpdateMessage(sprintf(_('Stopped hostapd@{%s}.service'), $iface));
+                }
+            }
+        } else {
+            $liveForm->sendUpdateMessage(_('Stopping Hotspot'), 40);
+            // stop default service
+            exec('sudo systemctl stop hostapd.service', $return);
+            foreach ($return as $line) {
+                $liveForm->sendUpdateMessage($line);
+            }
+        }
+
+        exec('sudo systemctl stop "raspap-network-activity@*.service"');
+        $liveForm->sendUpdateMessage(_('Stopped RaspAP Network Activity Monitor'), 40);
+
+        $liveForm->sendUpdateMessage(_('Hotspot Stopped'), 90);
+        $liveForm->saveStatusMessage(_('Hotspot Stopped'), 'success', true);
+        $liveForm->sendCompleteMessage();
+    }
+}
+
+$liveForm->saveStatusMessage(_('No Instructions to Complete'), 'warning');
+$liveForm->sendCompleteMessage();
+
+} catch (\Throwable $e) {
+    $liveForm->sendUpdateMessage(sprintf(_('An error occurred: %s'), $e->getMessage()), 100);
+    $liveForm->saveStatusMessage(_('An error occurred'), 'danger', true);
+    $liveForm->sendFailedMessage();
+}

--- a/ajax/page/openvpn.php
+++ b/ajax/page/openvpn.php
@@ -99,7 +99,7 @@ if (isset($_POST['SaveOpenVPNSettings'])) {
             $liveForm->sendUpdateMessage($line);
         }
 
-        $liveForm->sendUpdateMessage(_('Installing uploaded OpenVPN config'), 90);
+        $liveForm->sendUpdateMessage(_('Installing uploaded OpenVPN config'), 80);
         // Move uploaded ovpn config from /tmp and create symlink
         $client_ovpn = escapeshellarg(RASPI_OPENVPN_CLIENT_PATH.pathinfo($file['name'], PATHINFO_FILENAME).'_client.conf');
         chmod($tmp_ovpn, 0644);

--- a/ajax/page/openvpn.php
+++ b/ajax/page/openvpn.php
@@ -1,0 +1,154 @@
+<?php
+require_once '../../includes/autoload.php';
+require_once '../../includes/CSRF.php';
+require_once '../../includes/session.php';
+require_once '../../includes/config.php';
+require_once '../../includes/authenticate.php';
+require_once '../../includes/functions.php';
+
+$liveForm = new \RaspAP\UI\LiveForm();
+$liveForm->initAjax();
+$liveForm->sendStartMessage();
+
+try {
+
+if (RASPI_MONITOR_ENABLED) {
+    $liveForm->sendUpdateMessage(_('RaspAP Monitor Mode Enabled'), 100);
+    $liveForm->saveStatusMessage(_('RaspAP Monitor Mode Enabled'), 'warning');
+    $liveForm->sendCompleteMessage();
+}
+
+if (isset($_POST['SaveOpenVPNSettings'])) {
+    $liveForm->sendUpdateMessage(_('Saving OpenVPN configuration'), 10);
+
+    if (!isset($_POST['log-openvpn'])) {
+        $liveForm->sendUpdateMessage(_('Clearing OpenVPN log'), 20);
+        $f = @fopen("/tmp/openvpn.log", "r+");
+        if ($f !== false) {
+            ftruncate($f, 0);
+            fclose($f);
+        }
+    } elseif (isset($_POST['log-openvpn']) || (file_exists('/tmp/openvpn.log') && filesize('/tmp/openvpn.log') > 0)) {
+        $liveForm->sendUpdateMessage(_('Retrieving OpenVPN log'), 20);
+        exec("sudo /etc/raspap/openvpn/openvpnlog.sh", $logOutput);
+    }
+
+    if (isset($_POST['authUser'])) {
+        $authUser = strip_tags(trim($_POST['authUser']));
+    }
+    if (isset($_POST['authPassword'])) {
+        $authPassword = strip_tags(trim($_POST['authPassword']));
+    }
+
+    if (is_uploaded_file( $_FILES["customFile"]["tmp_name"])) {
+        define('KB', 1024);
+        $tmp_destdir = '/tmp/';
+        $auth_flag = 0;
+        $file = $_FILES['customFile'];
+
+        // If undefined or multiple files, treat as invalid
+        if (!isset($file['error']) || is_array($file['error'])) {
+            $liveForm->sendUpdateMessage(_('Invalid file parameters'), 90);
+            $liveForm->saveStatusMessage(_('Invalid file parameters'), 'danger', true);
+            $liveForm->sendFailedMessage();
+        }
+
+        $liveForm->sendUpdateMessage(_('Validating uploaded file'), 30);
+
+        $upload = \RaspAP\Uploader\FileUpload::factory('ovpn',$tmp_destdir);
+        $upload->set_max_file_size(64*KB);
+        $upload->set_allowed_mime_types(array('ovpn' => 'text/plain'));
+        $upload->file($file);
+
+        $validation = new validation;
+        $upload->callbacks($validation, array('check_name_length'));
+        $results = $upload->upload();
+
+        if (!empty($results['errors'])) {
+            $liveForm->sendUpdateMessage(_('Invalid file provided:'), 90);
+            $liveForm->sendUpdateMessage($results['errors'][0]);
+            $liveForm->saveStatusMessage(_('Invalid file provided'), 'danger', true);
+            $liveForm->sendFailedMessage();
+        }
+
+        // Good file upload, update auth credentials if present
+        if (!empty($authUser) && !empty($authPassword)) {
+            $liveForm->sendUpdateMessage(_('Updating authentication credentials'), 50);
+
+            $auth_flag = 1;
+            $tmp_authdata = $tmp_destdir .'ovpn/authdata';
+            $auth = $authUser . PHP_EOL . $authPassword . PHP_EOL;
+            file_put_contents($tmp_authdata, $auth);
+            chmod($tmp_authdata, 0644);
+            $client_auth = escapeshellarg(RASPI_OPENVPN_CLIENT_PATH.pathinfo($file['name'], PATHINFO_FILENAME).'_login.conf');
+            system("sudo mv $tmp_authdata $client_auth", $return);
+            system("sudo rm ".RASPI_OPENVPN_CLIENT_LOGIN, $return);
+            system("sudo ln -s $client_auth ".RASPI_OPENVPN_CLIENT_LOGIN, $return);
+            if ($return !=0) {
+                $liveForm->sendUpdateMessage(_('Unable to save client auth credentials'), 90);
+                $liveForm->saveStatusMessage(_('Unable to save client auth credentials'), 'danger', true);
+                $liveForm->sendFailedMessage();
+            }
+        }
+
+        $liveForm->sendUpdateMessage(null, 60);
+        // Set iptables rules and, optionally, auth-user-pass
+        $tmp_ovpn = $results['full_path'];
+        exec("sudo /etc/raspap/openvpn/configauth.sh $tmp_ovpn $auth_flag " . $_SESSION['ap_interface'], $return);
+        foreach ($return as $line) {
+            $liveForm->sendUpdateMessage($line);
+        }
+
+        $liveForm->sendUpdateMessage(_('Installing uploaded OpenVPN config'), 90);
+        // Move uploaded ovpn config from /tmp and create symlink
+        $client_ovpn = escapeshellarg(RASPI_OPENVPN_CLIENT_PATH.pathinfo($file['name'], PATHINFO_FILENAME).'_client.conf');
+        chmod($tmp_ovpn, 0644);
+        system("sudo mv $tmp_ovpn $client_ovpn", $return);
+        system("sudo rm ".RASPI_OPENVPN_CLIENT_CONFIG, $return);
+        system("sudo ln -s $client_ovpn ".RASPI_OPENVPN_CLIENT_CONFIG, $return);
+
+        if ($return == 0) {
+            $liveForm->sendUpdateMessage(_('OpenVPN client.conf uploaded successfully'), 90);
+        } else {
+            $liveForm->sendUpdateMessage(_('Unable to save OpenVPN client config'), 90);
+            $liveForm->saveStatusMessage(_('Unable to save OpenVPN client config'), 'danger', true);
+            $liveForm->sendFailedMessage();
+        }
+    }
+
+    $liveForm->saveStatusMessage(_('Saved settings successfully'), 'success', true);
+    $liveForm->sendCompleteMessage();
+} elseif (isset($_POST['StartOpenVPN'])) {
+    $liveForm->sendUpdateMessage(_('Attempting to start OpenVPN'), 30);
+
+    exec('sudo /bin/systemctl start openvpn-client@client', $return);
+    exec('sudo /bin/systemctl enable openvpn-client@client', $return);
+    foreach ($return as $line) {
+        $liveForm->sendUpdateMessage($line);
+    }
+
+    $liveForm->sendUpdateMessage(_('Started OpenVPN'), 90);
+    $liveForm->saveStatusMessage(_('OpenVPN started successfully'), 'success', true);
+    $liveForm->sendCompleteMessage();
+} elseif (isset($_POST['StopOpenVPN'])) {
+    $liveForm->sendUpdateMessage(_('Attempting to stop OpenVPN'), 30);
+
+    exec('sudo /bin/systemctl stop openvpn-client@client', $return);
+    exec('sudo /bin/systemctl disable openvpn-client@client', $return);
+    foreach ($return as $line) {
+        $liveForm->sendUpdateMessage($line);
+    }
+
+    $liveForm->sendUpdateMessage(_('Stopped OpenVPN'), 90);
+    $liveForm->saveStatusMessage(_('OpenVPN stopped successfully'), 'success', true);
+    $liveForm->sendCompleteMessage();
+}
+
+$liveForm->saveStatusMessage(_('No Instructions to Complete'), 'warning');
+$liveForm->sendCompleteMessage();
+
+} catch (\Throwable $e) {
+    $liveForm->sendUpdateMessage(sprintf(_('An error occurred: %s'), $e->getMessage()), 100);
+    $liveForm->saveStatusMessage(_('An error occurred'), 'danger', true);
+    $liveForm->sendFailedMessage();
+}

--- a/ajax/page/openvpn.php
+++ b/ajax/page/openvpn.php
@@ -21,18 +21,6 @@ if (RASPI_MONITOR_ENABLED) {
 if (isset($_POST['SaveOpenVPNSettings'])) {
     $liveForm->sendUpdateMessage(_('Saving OpenVPN configuration'), 10);
 
-    if (!isset($_POST['log-openvpn'])) {
-        $liveForm->sendUpdateMessage(_('Clearing OpenVPN log'), 20);
-        $f = @fopen("/tmp/openvpn.log", "r+");
-        if ($f !== false) {
-            ftruncate($f, 0);
-            fclose($f);
-        }
-    } elseif (isset($_POST['log-openvpn']) || (file_exists('/tmp/openvpn.log') && filesize('/tmp/openvpn.log') > 0)) {
-        $liveForm->sendUpdateMessage(_('Retrieving OpenVPN log'), 20);
-        exec("sudo /etc/raspap/openvpn/openvpnlog.sh", $logOutput);
-    }
-
     if (isset($_POST['authUser'])) {
         $authUser = strip_tags(trim($_POST['authUser']));
     }
@@ -49,6 +37,7 @@ if (isset($_POST['SaveOpenVPNSettings'])) {
         // If undefined or multiple files, treat as invalid
         if (!isset($file['error']) || is_array($file['error'])) {
             $liveForm->sendUpdateMessage(_('Invalid file parameters'), 90);
+            checkOpenVPNLog($liveForm);
             $liveForm->saveStatusMessage(_('Invalid file parameters'), 'danger', true);
             $liveForm->sendFailedMessage();
         }
@@ -67,6 +56,7 @@ if (isset($_POST['SaveOpenVPNSettings'])) {
         if (!empty($results['errors'])) {
             $liveForm->sendUpdateMessage(_('Invalid file provided:'), 90);
             $liveForm->sendUpdateMessage($results['errors'][0]);
+            checkOpenVPNLog($liveForm);
             $liveForm->saveStatusMessage(_('Invalid file provided'), 'danger', true);
             $liveForm->sendFailedMessage();
         }
@@ -86,6 +76,7 @@ if (isset($_POST['SaveOpenVPNSettings'])) {
             system("sudo ln -s $client_auth ".RASPI_OPENVPN_CLIENT_LOGIN, $return);
             if ($return !=0) {
                 $liveForm->sendUpdateMessage(_('Unable to save client auth credentials'), 90);
+                checkOpenVPNLog($liveForm);
                 $liveForm->saveStatusMessage(_('Unable to save client auth credentials'), 'danger', true);
                 $liveForm->sendFailedMessage();
             }
@@ -111,11 +102,13 @@ if (isset($_POST['SaveOpenVPNSettings'])) {
             $liveForm->sendUpdateMessage(_('OpenVPN client.conf uploaded successfully'), 90);
         } else {
             $liveForm->sendUpdateMessage(_('Unable to save OpenVPN client config'), 90);
+            checkOpenVPNLog($liveForm);
             $liveForm->saveStatusMessage(_('Unable to save OpenVPN client config'), 'danger', true);
             $liveForm->sendFailedMessage();
         }
     }
 
+    checkOpenVPNLog($liveForm);
     $liveForm->saveStatusMessage(_('Saved settings successfully'), 'success', true);
     $liveForm->sendCompleteMessage();
 } elseif (isset($_POST['StartOpenVPN'])) {
@@ -151,4 +144,19 @@ $liveForm->sendCompleteMessage();
     $liveForm->sendUpdateMessage(sprintf(_('An error occurred: %s'), $e->getMessage()), 100);
     $liveForm->saveStatusMessage(_('An error occurred'), 'danger', true);
     $liveForm->sendFailedMessage();
+}
+
+function checkOpenVPNLog($liveForm)
+{
+    if (!isset($_POST['log-openvpn'])) {
+        $liveForm->sendUpdateMessage(_('Clearing OpenVPN log'), 20);
+        $f = @fopen("/tmp/openvpn.log", "r+");
+        if ($f !== false) {
+            ftruncate($f, 0);
+            fclose($f);
+        }
+    } elseif (isset($_POST['log-openvpn']) || (file_exists('/tmp/openvpn.log') && filesize('/tmp/openvpn.log') > 0)) {
+        $liveForm->sendUpdateMessage(_('Retrieving OpenVPN log'), 20);
+        exec("sudo /etc/raspap/openvpn/openvpnlog.sh", $return);
+    }
 }

--- a/ajax/page/wireguard.php
+++ b/ajax/page/wireguard.php
@@ -1,0 +1,377 @@
+<?php
+require_once '../../includes/autoload.php';
+require_once '../../includes/CSRF.php';
+require_once '../../includes/session.php';
+require_once '../../includes/config.php';
+require_once '../../includes/authenticate.php';
+require_once '../../includes/functions.php';
+
+$liveForm = new \RaspAP\UI\LiveForm();
+$liveForm->initAjax();
+$liveForm->sendStartMessage();
+
+try {
+
+if (RASPI_MONITOR_ENABLED) {
+    $liveForm->sendUpdateMessage(_('RaspAP Monitor Mode Enabled'), 100);
+    $liveForm->saveStatusMessage(_('RaspAP Monitor Mode Enabled'), 'warning');
+    $liveForm->sendCompleteMessage();
+}
+
+$optRules     = isset($_POST['wgRules']) ? $_POST['wgRules'] : null;
+$optInterface = isset($_POST['wgInterface']) ? $_POST['wgInterface'] : null;
+$optConf      = isset($_POST['wgCnfOpt']) ? $_POST['wgCnfOpt'] : null;
+$optSrvEnable = isset($_POST['wgSrvEnable']) ? $_POST['wgSrvEnable'] : null;
+$optLogEnable = isset($_POST['wgLogEnable']) ? $_POST['wgLogEnable'] : null;
+$optKSwitch   = isset($_POST['wgKSwitch']) ? $_POST['wgKSwitch'] : null;
+
+if (isset($_POST['savewgsettings'])) {
+    $liveForm->sendUpdateMessage(_('Saving WireGuard configuration'), 10);
+
+    if ($optConf == 'manual' && $optSrvEnable == 1 ) {
+        SaveWireGuardConfig($liveForm, $optLogEnable);
+    } elseif ($optConf == 'upload' && is_uploaded_file($_FILES["wgFile"]["tmp_name"])) {
+        SaveWireGuardUpload($liveForm, $_FILES['wgFile'], $optRules, $optKSwitch, $optInterface, $optLogEnable);
+    } elseif (isset($_POST['wg_penabled']) ) {
+        SaveWireGuardConfig($liveForm, $optLogEnable);
+    }
+
+    $liveForm->sendUpdateMessage(null, 50);
+    CheckWireGuardLog($optLogEnable, $liveForm);
+
+    $liveForm->sendUpdateMessage(_('WireGuard configuration saved successfully'), 90);
+    $liveForm->saveStatusMessage(_('WireGuard configuration saved successfully'), 'success', true);
+    $liveForm->sendCompleteMessage();
+} elseif (isset($_POST['startwg']) || isset($_POST['stopwg'])) {
+    if (isset($_POST['startwg'])) {
+        $liveForm->sendUpdateMessage(_('Attempting to start WireGuard'), 30);
+
+        exec('sudo /bin/systemctl enable wg-quick@wg0', $return);
+        exec('sudo /bin/systemctl start wg-quick@wg0', $return);
+        foreach ($return as $line) {
+            $liveForm->sendUpdateMessage($line);
+        }
+
+        $liveForm->sendUpdateMessage(_('Started WireGuard successfully'), 90);
+        $liveForm->saveStatusMessage(_('Started WireGuard successfully'), 'success', true);
+        $liveForm->sendCompleteMessage();
+    } elseif (isset($_POST['stopwg'])) {
+        $liveForm->sendUpdateMessage(_('Attempting to stop WireGuard'), 30);
+
+        exec('sudo /bin/systemctl stop wg-quick@wg0', $return);
+        exec('sudo /bin/systemctl disable wg-quick@wg0', $return);
+        foreach ($return as $line) {
+            $liveForm->sendUpdateMessage($line);
+        }
+
+        $liveForm->sendUpdateMessage(_('Stopped WireGuard successfully'), 90);
+        $liveForm->saveStatusMessage(_('Stopped WireGuard successfully'), 'success', true);
+        $liveForm->sendCompleteMessage();
+    }
+}
+
+$liveForm->saveStatusMessage(_('No Instructions to Complete'), 'warning');
+$liveForm->sendCompleteMessage();
+
+} catch (\Throwable $e) {
+    $liveForm->sendUpdateMessage(sprintf(_('An error occurred: %s'), $e->getMessage()), 100);
+    $liveForm->saveStatusMessage(_('An error occurred'), 'danger', true);
+    $liveForm->sendFailedMessage();
+}
+
+/**
+ * Validates uploaded .conf file, adds iptables post-up and
+ * post-down rules.
+ *
+ * @param  object $liveForm
+ * @param  object $file
+ * @param  boolean $optRules
+ * @param  boolean $optKSwitch
+ * @param  string $optInterface
+ * @param  boolean $optLogEnable
+ * @return object $status
+ */
+function SaveWireGuardUpload($liveForm, $file, $optRules, $optKSwitch, $optInterface, $optLogEnable)
+{
+    define('KB', 1024);
+    $tmp_destdir = '/tmp/';
+    $auth_flag = 0;
+
+    // If undefined or multiple files, treat as invalid
+    if (!isset($file['error']) || is_array($file['error'])) {
+        $liveForm->sendUpdateMessage(_('Invalid file parameters'), 90);
+        $liveForm->saveStatusMessage(_('Invalid file parameters'), 'danger', true);
+        CheckWireGuardLog($optLogEnable, $liveForm);
+        $liveForm->sendFailedMessage();
+    }
+
+    $liveForm->sendUpdateMessage(_('Validating uploaded file'), 30);
+
+    $upload = \RaspAP\Uploader\FileUpload::factory('wg',$tmp_destdir);
+    $upload->set_max_file_size(64*KB);
+    $upload->set_allowed_mime_types(array('text/plain'));
+    $upload->file($file);
+
+    $validation = new validation;
+    $upload->callbacks($validation, array('check_name_length'));
+    $results = $upload->upload();
+
+    if (!empty($results['errors'])) {
+        $liveForm->sendUpdateMessage(_('Invalid file provided:'), 90);
+        $liveForm->sendUpdateMessage($results['errors'][0]);
+        $liveForm->saveStatusMessage(_('Invalid file provided'), 'danger', true);
+        CheckWireGuardLog($optLogEnable, $liveForm);
+        $liveForm->sendFailedMessage();
+    }
+
+    // Valid upload, get file contents
+    $tmp_wgconfig = $results['full_path'];
+    $tmp_contents = file_get_contents($tmp_wgconfig);
+
+    // Check for existing iptables rules
+    if ((isset($optRules) || isset($optKSwitch)) && preg_match('/PostUp|PostDown|PreDown/m',$tmp_contents)) {
+        $liveForm->sendUpdateMessage(_('Existing iptables rules found in WireGuard configuration - Skipping'));
+    } else {
+        // Set rules from default config
+        if (isset($optRules)) {
+            $rules[] = 'PostUp = '.getDefaultNetValue('wireguard','server','PostUp');
+            $rules[] = 'PostDown = '.getDefaultNetValue('wireguard','server','PostDown');
+            $rules = preg_replace('/wlan0/m', $optInterface, $rules);
+        }
+        if (isset($optKSwitch)) {
+            // Get ap static ip_addr from system config, fallback to default if undefined
+            $jsonData = json_decode(getNetConfig($optInterface), true);
+            $ip_addr = ($jsonData['StaticIP'] ?? '') === '' ? getDefaultNetValue('dhcp', $optInterface, 'static ip_address') : $jsonData['StaticIP'];
+            $mask = ($jsonData['SubnetMask'] ?? '') === '' ? getDefaultNetValue('dhcp', $optInterface, 'subnetmask') : $jsonData['SubnetMask'];
+
+            // if empty, try to detect IP/mask from system
+            if (empty($ip_addr) || empty($mask)) {
+                $ipDetails = shell_exec("ip -4 -o addr show dev " . escapeshellarg($optInterface));
+                if (preg_match('/inet (\d+\.\d+\.\d+\.\d+)\/(\d+)/', $ipDetails, $matches)) {
+                    $ip_addr = $matches[1];
+                    $cidr = $matches[2];
+                } else {
+                    $ip_addr = '0.0.0.0';
+                    $cidr = '24';
+                }
+            } else {
+                $cidr = mask2cidr($mask);
+            }
+            $cidr_ip = strpos($ip_addr, '/') === false ? "$ip_addr/$cidr" : $ip_addr;
+
+            $rules[] = 'PostUp = '.getDefaultNetValue('wireguard','server','PostUpEx');
+            $rules[] = 'PreDown = '.getDefaultNetValue('wireguard','server','PreDown');
+            $rules = preg_replace('/%s/m', $cidr_ip, $rules);
+        }
+        if ((isset($rules) && count($rules) > 0)) {
+            $rules[] = '';
+            $rules = join(PHP_EOL, $rules);
+            $tmp_contents = preg_replace('/^\s*$/ms', $rules, $tmp_contents, 1);
+            file_put_contents($tmp_wgconfig, $tmp_contents);
+
+            $liveForm->sendUpdateMessage(_('iptables rules added to WireGuard configuration'));
+        }
+    }
+
+    $liveForm->sendUpdateMessage(_('Installing uploaded WireGuard config'), 80);
+    // Sanitize, move processed file from /tmp and create symlink
+    $stem = preg_replace('/[^A-Za-z0-9\-_]/', '_', pathinfo($file['name'], PATHINFO_FILENAME));
+    $client_wg = RASPI_WIREGUARD_PATH.$stem.'.conf';
+    chmod($tmp_wgconfig, 0644);
+    system("sudo mv ".escapeshellarg($tmp_wgconfig)." ".escapeshellarg($client_wg), $return);
+    system("sudo rm ".RASPI_WIREGUARD_CONFIG, $return);
+    system("sudo ln -s ".escapeshellarg($client_wg)." ".RASPI_WIREGUARD_CONFIG, $return);
+
+    if ($return ==0) {
+        $liveForm->sendUpdateMessage(_('WireGuard configuration uploaded successfully'), 90);
+    } else {
+        $liveForm->sendUpdateMessage(_('Unable to save WireGuard configuration'), 90);
+        $liveForm->saveStatusMessage(_('Unable to save WireGuard configuration'), 'danger', true);
+        CheckWireGuardLog($optLogEnable, $liveForm);
+        $liveForm->sendFailedMessage();
+    }
+
+    $liveForm->saveStatusMessage(_('Saved settings successfully'), 'success', true);
+    CheckWireGuardLog($optLogEnable, $liveForm);
+    $liveForm->sendCompleteMessage();
+}
+
+/**
+ * Validate user input, save wireguard configuration
+ *
+ * @param object $liveForm
+ * @param boolean $optLogEnable
+ * @return boolean
+ */
+function SaveWireGuardConfig($liveForm, $optLogEnable)
+{
+    // Set defaults
+    $good_input = true;
+    $peer_id = 1;
+
+    // Validate server input
+    if ($_POST['wgSrvEnable'] == 1) {
+        $liveForm->sendUpdateMessage(_('Validating server inputs'), 20);
+        if (isset($_POST['wg_srvport'])) {
+            if (strlen($_POST['wg_srvport']) > 5 || !is_numeric($_POST['wg_srvport'])) {
+                $liveForm->sendUpdateMessage(_('Invalid value for server local port'));
+                $good_input = false;
+            }
+        }
+        if (isset($_POST['wg_plistenport'])) {
+            if (strlen($_POST['wg_plistenport']) > 5 || !is_numeric($_POST['wg_plistenport'])) {
+                $liveForm->sendUpdateMessage(_('Invalid value for peer local port'));
+                $good_input = false;
+            }
+        }
+        if (isset($_POST['wg_srvipaddress'])) {
+            if (!validateCidr($_POST['wg_srvipaddress'])) {
+                $liveForm->sendUpdateMessage(_('Invalid value for server IP address'));
+                $good_input = false;
+            }
+        }
+        if (isset($_POST['wg_srvdns'])) {
+            if (!filter_var($_POST['wg_srvdns'],FILTER_VALIDATE_IP)) {
+                $liveForm->sendUpdateMessage(_('Invalid value for DNS'));
+                $good_input = false;
+            }
+        }
+    }
+
+    // Validate peer input
+    if ($_POST['wg_penabled'] == 1) {
+        $liveForm->sendUpdateMessage(_('Validating peer inputs'), 30);
+        if (isset($_POST['wg_pipaddress'])) {
+            if (!validateCidr($_POST['wg_pipaddress'])) {
+                $liveForm->sendUpdateMessage(_('Invalid value for peer IP address'));
+                $good_input = false;
+            }
+        }
+        if (isset($_POST['wg_pendpoint']) && strlen(trim($_POST['wg_pendpoint']) >0 )) {
+            $wg_pendpoint_seg = substr($_POST['wg_pendpoint'],0,strpos($_POST['wg_pendpoint'],':'));
+            $host_port = explode(':', $wg_pendpoint_seg);
+            $hostname = $host_port[0];
+            if (
+                !filter_var($hostname, FILTER_VALIDATE_IP) &&
+                !filter_var($hostname, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)
+            ) {
+                $liveForm->sendUpdateMessage(_('Invalid value for endpoint address'));
+                $good_input = false;
+            }
+        }
+        if (isset($_POST['wg_pallowedips']) && strlen(trim($_POST['wg_pallowedips']) >0)) {
+            if (!validateCidr($_POST['wg_pallowedips'])) {
+                $liveForm->sendUpdateMessage(_('Invalid value for allowed IPs'));
+                $good_input = false;
+            }
+        }
+        if (isset($_POST['wg_pkeepalive']) && strlen(trim($_POST['wg_pkeepalive']) >0 )) {
+            if (strlen($_POST['wg_pkeepalive']) > 4 || !is_numeric($_POST['wg_pkeepalive'])) {
+                $liveForm->sendUpdateMessage(_('Invalid value for persistent keepalive'));
+                $good_input = false;
+            }
+        }
+    }
+
+    // Save settings
+    if ($good_input) {
+        $liveForm->sendUpdateMessage(_('Inputs Valid'));
+        // server (wg0.conf)
+        if ($_POST['wgSrvEnable'] == 1) {
+            $liveForm->sendUpdateMessage(_('Enabling Server'), 40);
+            // fetch server private key from filesytem
+            $wg_srvprivkey = exec('sudo cat '. RASPI_WIREGUARD_PATH .'wg-server-private.key', $return);
+            $config[] = '[Interface]';
+            $config[] = 'Address = '.$_POST['wg_srvipaddress'];
+            $config[] = 'ListenPort = '.$_POST['wg_srvport'];
+            $config[] = 'DNS = '.$_POST['wg_srvdns'];
+            $config[] = 'PrivateKey = '.$wg_srvprivkey;
+            $config[] = 'PostUp = '.getDefaultNetValue('wireguard','server','PostUp');
+            $config[] = 'PostDown = '.getDefaultNetValue('wireguard','server','PostDown');
+            $config[] = '';
+            $config[] = '[Peer]';
+            $config[] = 'PublicKey = '.$_POST['wg-peer'];
+            $config[] = 'AllowedIPs = '.$_POST['wg_pallowedips'];
+            if ($_POST['wg_pkeepalive'] !== '') {
+                $config[] = 'PersistentKeepalive = '.trim($_POST['wg_pkeepalive']);
+            }
+            $config[] = '';
+            $config = join(PHP_EOL, $config);
+
+            file_put_contents("/tmp/wgdata", $config);
+            system('sudo cp /tmp/wgdata '.RASPI_WIREGUARD_CONFIG, $return);
+        } else {
+            $liveForm->sendUpdateMessage(_('Disabling Server'), 40);
+            # remove selected conf + keys
+            system('sudo rm '. RASPI_WIREGUARD_PATH .'wg-server-private.key', $return);
+            system('sudo rm '. RASPI_WIREGUARD_PATH .'wg-server-public.key', $return);
+            system('sudo rm '. RASPI_WIREGUARD_CONFIG, $return);
+        }
+        // client1 (client.conf)
+        if ($_POST['wg_penabled'] == 1) {
+            $liveForm->sendUpdateMessage(_('Enabling Peer'), 50);
+            // fetch peer private key from filesystem 
+            $wg_peerprivkey = exec('sudo cat '. RASPI_WIREGUARD_PATH .'wg-peer-private.key', $return);
+            $config = [];
+            $config[] = '[Interface]';
+            $config[] = 'Address = '.trim($_POST['wg_pipaddress']);
+            $config[] = 'PrivateKey = '.$wg_peerprivkey;
+            $config[] = 'ListenPort = '.$_POST['wg_plistenport'];
+            $config[] = '';
+            $config[] = '[Peer]';
+            $config[] = 'PublicKey = '.$_POST['wg-server'];
+            $config[] = 'AllowedIPs = '.$_POST['wg_pallowedips'];
+            $config[] = 'Endpoint = '.$_POST['wg_pendpoint'];
+            if ($_POST['wg_pkeepalive'] !== '') {
+                $config[] = 'PersistentKeepalive = '.trim($_POST['wg_pkeepalive']);
+            }
+            $config[] = '';
+            $config = join(PHP_EOL, $config);
+            file_put_contents("/tmp/wgdata", $config);
+            system('sudo cp /tmp/wgdata '.RASPI_WIREGUARD_PATH.'client.conf', $return);
+        } else {
+            $liveForm->sendUpdateMessage(_('Disabling Peer'), 50);
+            # remove selected conf + keys
+            system('sudo rm '. RASPI_WIREGUARD_PATH .'wg-peer-private.key', $return);
+            system('sudo rm '. RASPI_WIREGUARD_PATH .'wg-peer-public.key', $return);
+            system('sudo rm '. RASPI_WIREGUARD_PATH.'client.conf', $return);
+        }
+
+        foreach ($return as $line) {
+            $liveForm->sendUpdateMessage($line);
+        }
+
+        if ($return == 0) {
+            $liveForm->sendUpdateMessage(_('WireGuard configuration updated successfully'), 90);
+            $liveForm->saveStatusMessage('WireGuard configuration updated successfully', 'success', true);
+            CheckWireGuardLog($optLogEnable, $liveForm);
+            $liveForm->sendCompleteMessage();
+        } else {
+            $liveForm->sendUpdateMessage(_('WireGuard configuration failed to be updated'), 90);
+            $liveForm->saveStatusMessage(_('WireGuard configuration failed to be updated'), 'danger', true);
+            CheckWireGuardLog($optLogEnable, $liveForm);
+            $liveForm->sendFailedMessage();
+        }
+    } else {
+        $liveForm->sendUpdateMessage(_('Unable to save WireGurad config due to invalid input'), 90);
+        $liveForm->saveStatusMessage(_('Unable to save WireGurad config due to invalid input'), 'danger', true);
+        CheckWireGuardLog($optLogEnable, $liveForm);
+        $liveForm->sendFailedMessage();
+    }
+}
+
+function CheckWireGuardLog($opt, $liveForm)
+{
+   // handle log option
+    if ($opt != '1') {
+        $liveForm->sendUpdateMessage(_('Clearing WireGuard log'), 20);
+        $f = @fopen("/tmp/wireguard.log", "r+");
+        if ($f !== false) {
+            ftruncate($f, 0);
+            fclose($f);
+        }
+    } elseif ($opt == "1" || (file_exists('/tmp/wireguard.log') && filesize('/tmp/wireguard.log') > 0)) {
+        exec("sudo journalctl --identifier wg-quick > /tmp/wireguard.log");
+        $liveForm->sendUpdateMessage(_('WireGuard debug log updated'));
+    }
+}

--- a/app/css/base.css
+++ b/app/css/base.css
@@ -240,6 +240,20 @@ button.btn i:not([class*="service-status"]) {
   font-size: 1.3rem;
 }
 
+#liveFormModalCurrentMessage {
+  position: relative;
+  white-space: nowrap;
+  overflow: hidden;
+}
+#liveFormModalCurrentMessage::after {
+  content: '';
+  position: absolute;
+  background: linear-gradient(90deg, transparent 0%, white 90%);
+  right: 0;
+  width: 10%;
+  height: 100%;
+}
+
 /* Improved progress bar */
 .progress.progress-improved {
   position: relative;

--- a/app/css/base.css
+++ b/app/css/base.css
@@ -254,6 +254,42 @@ button.btn i:not([class*="service-status"]) {
   height: 100%;
 }
 
+form.live-form[inert] {
+  position: relative;
+}
+form.live-form[inert]::before {
+  --live-form-overlay-spacer-y: -2px;
+  --live-form-overlay-spacer-x: -2px;
+  content: "";
+  position: absolute;
+  top: var(--live-form-overlay-spacer-y);
+  right: var(--live-form-overlay-spacer-x);
+  bottom: var(--live-form-overlay-spacer-y);
+  left: var(--live-form-overlay-spacer-x);
+  backdrop-filter: blur(3px);
+  z-index: 1;
+}
+.card-body form.live-form:not(.lf-spinner-sm)[inert]::before {
+  --live-form-overlay-spacer-y: -1rem;
+  --live-form-overlay-spacer-x: -1rem;
+}
+form.live-form[inert]::after {
+  --live-form-spinner-size: 3rem;
+  content: "";
+  font-family: "Font Awesome 5 Free";
+  animation: loading-spin 1.2s linear infinite;
+  font-weight: bold;
+  font-size: var(--live-form-spinner-size);
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  z-index: 2;
+}
+.card-header form.live-form[inert]::after,
+form.live-form.lf-spinner-sm[inert]::after {
+  --live-form-spinner-size: 1rem;
+}
+
 /* Improved progress bar */
 .progress.progress-improved {
   position: relative;

--- a/app/css/themes/default.php
+++ b/app/css/themes/default.php
@@ -193,6 +193,10 @@ html[data-bs-theme="dark"] .modal:not(#modal-admin-login) .modal-footer {
   color: var(--bs-light) !important;
 }
 
+#liveFormModalCurrentMessage::after {
+  background: linear-gradient(90deg, transparent 0%, var(--bs-dark) 90%);
+}
+
 html[data-bs-theme="dark"] .card,
 html[data-bs-theme="dark"] .card-footer,
 html[data-bs-theme="dark"] .modal:not(#modal-admin-login) .modal-body,

--- a/app/css/themes/default.php
+++ b/app/css/themes/default.php
@@ -193,7 +193,7 @@ html[data-bs-theme="dark"] .modal:not(#modal-admin-login) .modal-footer {
   color: var(--bs-light) !important;
 }
 
-#liveFormModalCurrentMessage::after {
+html[data-bs-theme="dark"] #liveFormModalCurrentMessage::after {
   background: linear-gradient(90deg, transparent 0%, var(--bs-dark) 90%);
 }
 

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -189,6 +189,32 @@ document.addEventListener('DOMContentLoaded', () => {
                     messageHistory.append($('<div>').text(json.message));
                     messageHistory.scrollTop(messageHistory.prop("scrollHeight"));
                 }
+            },
+            onCompleteMessage: (json) => {
+                $(modalEl).find('#liveFormModalProgressBar').addClass('bg-success');
+            },
+            onFailedMessage: (json) => {
+                $(modalEl).find('#liveFormModalProgressBar').addClass('bg-danger');
+
+                let closeButton = $('<button>')
+                    .addClass('btn btn-outline-primary')
+                    .attr('type', 'button')
+                    .text('Close')
+                    .on('click', () => {
+                        modal.hide();
+                    });
+                let reloadButton = $('<button>')
+                    .addClass('btn btn-primary')
+                    .attr('type', 'button')
+                    .text('Reload Page')
+                    .on('click', () => {
+                        window.location.reload();
+                    });
+                $(modalEl)
+                    .find('.modal-footer')
+                    .append(closeButton)
+                    .append(reloadButton)
+                    .show();
             }
         });
     };

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -178,11 +178,12 @@ document.addEventListener('DOMContentLoaded', () => {
         modal.show();
 
         await fetchLiveFormStream(action, formData, {
-            onUpdateMessage: (json) => {
+            onMessage: (json) => {
                 if (json.progress) {
                     $(modalEl).find('#liveFormModalProgressBar').css('width', json.progress + '%');
                 }
-
+            },
+            onUpdateMessage: (json) => {
                 if (json.message) {
                     $(modalEl).find('#liveFormModalCurrentMessage').text(json.message);
                     const messageHistory = $(modalEl).find('#liveFormModalMessageHistory');
@@ -221,6 +222,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     async function fetchLiveFormStream(action, formData, options = {}) {
         let defaultOptions = {
+            onMessage: null,
             onUpdateMessage: null,
             onCompleteMessage: null,
             onFailedMessage: null,
@@ -256,6 +258,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (part.startsWith('data: ')) {
                     const data = part.replace(/^data: /, '').trim();
                     let json = JSON.parse(data);
+
+                    if (options?.onMessage) {
+                        options.onMessage(json);
+                    }
 
                     if (json.status === 'RUNNING' && options?.onUpdateMessage) {
                         options.onUpdateMessage(json);

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -162,6 +162,12 @@ document.addEventListener('DOMContentLoaded', () => {
         
         if (!form || !action || !modal) return;
 
+        // Clear previous modal state
+        $(modalEl).find('#liveFormModalProgressBar').removeClass('bg-success bg-danger').css('width', '0%');
+        $(modalEl).find('#liveFormModalCurrentMessage').text('');
+        $(modalEl).find('#liveFormModalMessageHistory').empty();
+        $(modalEl).find('.modal-footer').empty().hide();
+
         const formData = new FormData(form);
         console.log(formData);
 

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -146,13 +146,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
                 // if form has `live-form` class, handle live form submission
                 if (form.classList.contains('live-form')) {
-                    handleLiveForm(event);
+                    handleLiveFormSubmission(event);
                 }
             }, false);
         });
     }, false);
 
-    async function handleLiveForm(e) {
+    async function handleLiveFormSubmission(e) {
         e.preventDefault();
 
         const form = e.target;
@@ -176,6 +176,32 @@ document.addEventListener('DOMContentLoaded', () => {
         if (newTitle) $(modalEl).find('#liveFormModalTitle').text(newTitle);
 
         modal.show();
+
+        await fetchLiveFormStream(action, formData, {
+            onUpdateMessage: (json) => {
+                if (json.progress) {
+                    $(modalEl).find('#liveFormModalProgressBar').css('width', json.progress + '%');
+                }
+
+                if (json.message) {
+                    $(modalEl).find('#liveFormModalCurrentMessage').text(json.message);
+                    const messageHistory = $(modalEl).find('#liveFormModalMessageHistory');
+                    messageHistory.append($('<div>').text(json.message));
+                    messageHistory.scrollTop(messageHistory.prop("scrollHeight"));
+                }
+            }
+        });
+    };
+
+    async function fetchLiveFormStream(action, formData, options = {}) {
+        let defaultOptions = {
+            onUpdateMessage: null,
+            onCompleteMessage: null,
+            onFailedMessage: null,
+            reloadOnComplete: true,
+            reloadOnFailed: false
+        };
+        options = { ...defaultOptions, ...options };
 
         const response = await fetch(action, {
             method: 'POST',
@@ -205,23 +231,25 @@ document.addEventListener('DOMContentLoaded', () => {
                     const data = part.replace(/^data: /, '').trim();
                     let json = JSON.parse(data);
 
-                    if (json.progress) {
-                        $(modalEl).find('#liveFormModalProgressBar').css('width', json.progress + '%');
-                    }
-
-                    if (json.message) {
-                        $(modalEl).find('#liveFormModalCurrentMessage').text(json.message);
-                        const messageHistory = $(modalEl).find('#liveFormModalMessageHistory');
-                        messageHistory.append($('<div>').text(json.message));
-                        messageHistory.scrollTop(messageHistory.prop("scrollHeight"));
+                    if (json.status === 'RUNNING' && options?.onUpdateMessage) {
+                        options.onUpdateMessage(json);
                     }
 
                     if (json.status === 'COMPLETE' || json.status === 'FAILED') {
                         reader.cancel();
-                        setTimeout(() => {
-                            window.location.reload();
-                        }, 1000);
-                        return;
+                        if (json.status === 'COMPLETE' && options?.onCompleteMessage) {
+                            options.onCompleteMessage(json);
+                        }
+
+                        if (json.status === 'FAILED' && options?.onFailedMessage) {
+                            options.onFailedMessage(json);
+                        }
+
+                        if (options?.reloadOnComplete || options?.reloadOnFailed) {
+                            setTimeout(() => {
+                                window.location.reload();
+                            }, 1000);
+                        }
                     }
                 }
             }

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -130,21 +130,101 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
-    // Event listener for Bootstrap's form validation
+    // Event listener for custom from validation and live form handling
     window.addEventListener('load', function() {
-        // Fetch all the forms we want to apply custom Bootstrap validation styles to
-        var forms = document.getElementsByClassName('needs-validation');
-        // Loop over them and prevent submission
+        var forms = document.getElementsByTagName('form');
         var validation = Array.prototype.filter.call(forms, function(form) {
             form.addEventListener('submit', function(event) {
-            if (form.checkValidity() === false) {
-                event.preventDefault();
-                event.stopPropagation();
-            }
-            form.classList.add('was-validated');
+                // if form has bootstrap `needs-validation` class, perform validation checks
+                if (form.classList.contains('needs-validation')) {
+                    if (form.checkValidity() === false) {
+                        event.preventDefault();
+                        event.stopPropagation();
+                    }
+                    form.classList.add('was-validated');
+                }
+
+                // if form has `live-form` class, handle live form submission
+                if (form.classList.contains('live-form')) {
+                    handleLiveForm(event);
+                }
             }, false);
         });
     }, false);
+
+    async function handleLiveForm(e) {
+        e.preventDefault();
+
+        const form = e.target;
+        const action = form.action;
+        const modalEl = document.getElementById('liveFormModal');
+        const modal = new bootstrap.Modal(modalEl, { keyboard: false });
+        
+        if (!form || !action || !modal) return;
+
+        const formData = new FormData(form);
+        console.log(formData);
+
+        // Get data from submitting button if exists
+        const submitter = e.submitter || null;
+        if (submitter && submitter.name) {
+            formData.append(submitter.name, submitter?.value || '');
+        }
+
+        // set initial modal content
+        let newTitle = $(submitter)?.data('modal-title') || $(form).data('modal-title');
+        if (newTitle) $(modalEl).find('#liveFormModalTitle').text(newTitle);
+
+        modal.show();
+
+        const response = await fetch(action, {
+            method: 'POST',
+            body: formData
+        });
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+
+        while (true) {
+            const { done, value } = await reader.read();
+
+            if (done) break;
+
+            // Accumulate chunks into a buffer
+            buffer += decoder.decode(value, { stream: true });
+
+            // Split on SSE message boundaries
+            const parts = buffer.split('\n\n');
+
+            // Last element may be an incomplete message — keep it in the buffer
+            buffer = parts.pop();
+
+            for (const part of parts) {
+                if (part.startsWith('data: ')) {
+                    const data = part.replace(/^data: /, '').trim();
+                    let json = JSON.parse(data);
+
+                    if (json.progress) {
+                        $(modalEl).find('#liveFormModalProgressBar').css('width', json.progress + '%');
+                    }
+
+                    if (json.message) {
+                        $(modalEl).find('#liveFormModalCurrentMessage').text(json.message);
+                        const messageHistory = $(modalEl).find('#liveFormModalMessageHistory');
+                        messageHistory.append($('<div>').text(json.message));
+                        messageHistory.scrollTop(messageHistory.prop("scrollHeight"));
+                    }
+
+                    if (json.status === 'COMPLETE' || json.status === 'FAILED') {
+                        reader.cancel();
+                        window.location.reload();
+                        return;
+                    }
+                }
+            }
+        }
+    };
 
     // Input masks
     $('.ip_address').mask('0ZZ.0ZZ.0ZZ.0ZZ', {

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -218,7 +218,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
                     if (json.status === 'COMPLETE' || json.status === 'FAILED') {
                         reader.cancel();
-                        window.location.reload();
+                        setTimeout(() => {
+                            window.location.reload();
+                        }, 1000);
                         return;
                     }
                 }

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -169,7 +169,6 @@ document.addEventListener('DOMContentLoaded', () => {
         $(modalEl).find('.modal-footer').empty().hide();
 
         const formData = new FormData(form);
-        console.log(formData);
 
         // Get data from submitting button if exists
         const submitter = e.submitter || null;

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -134,6 +134,11 @@ document.addEventListener('DOMContentLoaded', () => {
     window.addEventListener('load', function() {
         var forms = document.getElementsByTagName('form');
         var validation = Array.prototype.filter.call(forms, function(form) {
+            // remove inert attribute on forms with live-form class to allow interaction when js loads
+            if (form.classList.contains('live-form')) {
+                form.removeAttribute('inert');
+            }
+            
             form.addEventListener('submit', function(event) {
                 // if form has bootstrap `needs-validation` class, perform validation checks
                 if (form.classList.contains('needs-validation')) {

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -138,7 +138,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (form.classList.contains('live-form')) {
                 form.removeAttribute('inert');
             }
-            
+
             form.addEventListener('submit', function(event) {
                 // if form has bootstrap `needs-validation` class, perform validation checks
                 if (form.classList.contains('needs-validation')) {
@@ -232,6 +232,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     async function fetchLiveFormStream(action, formData, options = {}) {
         let defaultOptions = {
+            method: 'POST',
             onMessage: null,
             onUpdateMessage: null,
             onCompleteMessage: null,
@@ -242,7 +243,7 @@ document.addEventListener('DOMContentLoaded', () => {
         options = { ...defaultOptions, ...options };
 
         const response = await fetch(action, {
-            method: 'POST',
+            method: options.method || 'POST',
             body: formData
         });
 

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -162,6 +162,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const form = e.target;
         const action = form.action;
+        const method = form.method;
         const modalEl = document.getElementById('liveFormModal');
         const modal = new bootstrap.Modal(modalEl, { keyboard: false });
         
@@ -188,6 +189,7 @@ document.addEventListener('DOMContentLoaded', () => {
         modal.show();
 
         await fetchLiveFormStream(action, formData, {
+            method: method,
             onMessage: (json) => {
                 if (json.progress) {
                     $(modalEl).find('#liveFormModalProgressBar').css('width', json.progress + '%');

--- a/includes/adblock.php
+++ b/includes/adblock.php
@@ -12,56 +12,7 @@ function DisplayAdBlockConfig()
     $enabled = false;
     $custom_enabled = false;
 
-    if (!RASPI_MONITOR_ENABLED) {
-        if (isset($_POST['saveadblocksettings'])) {
-            if ($_POST['adblock-enable'] == "1") {
-                $config = 'conf-file=' .RASPI_ADBLOCK_LISTPATH .'domains.txt'.PHP_EOL;
-                $config.= 'addn-hosts=' .RASPI_ADBLOCK_LISTPATH .'hostnames.txt'.PHP_EOL;
-            } elseif ($_POST['adblock-enable'] == "0") {
-                $config = null;
-            }
-            if ($_POST['adblock-custom-enable'] == "1") {
-                // validate custom hosts input
-                $lines = preg_split('/\r\n|\n|\r/', trim($_POST['adblock-custom-hosts']));
-                if (!in_array("", $lines, true)) {
-                    foreach ($lines as $line) {
-                        $ip_host = preg_split('/\s+/', $line);
-                        $index++;
-                        if (!filter_var($ip_host[0], FILTER_VALIDATE_IP)) {
-                            $errors .= _('Invalid custom IP address found on line '.$index);
-                            break;
-                        }
-                        if (!validate_host($ip_host[1])) {
-                            $errors .= _('Invalid custom host found on line '.$index);
-                            break;
-                        }
-                    }
-                }
-                file_put_contents("/tmp/dnsmasq_custom", $_POST['adblock-custom-hosts'].PHP_EOL);
-                system("sudo cp /tmp/dnsmasq_custom " .RASPI_ADBLOCK_LISTPATH .'custom.txt', $return);
-                $config.= 'addn-hosts=' .RASPI_ADBLOCK_LISTPATH .'custom.txt'.PHP_EOL;
-            }
-
-            if (empty($errors)) {
-                file_put_contents("/tmp/dnsmasqdata", $config);
-                system('sudo cp /tmp/dnsmasqdata '.RASPI_ADBLOCK_CONFIG, $return);
-                if ($return == 0) {
-                    $status->addMessage('Adblock configuration updated successfully', 'success');
-                } else {
-                    $status->addMessage('Adblock configuration failed to be updated.', 'danger');
-                }
-            } else {
-                $status->addMessage($errors, 'danger');
-            }
-        } elseif (isset($_POST['restartadblock']) || isset($_POST['startadblock'])) {
-            exec('sudo /bin/systemctl restart dnsmasq.service', $dnsmasq, $return);
-            if ($return == 0) {
-                $status->addMessage('Adblock restart successful', 'success');
-            } else {
-                $status->addMessage('Adblock failed to restart.', 'danger');
-            }
-        }
-    }
+    \RaspAP\UI\LiveForm::loadStatusMessages($status);
 
     $custom_list = RASPI_ADBLOCK_LISTPATH . 'custom.txt';
     $custom_enabled = false;

--- a/includes/dhcp.php
+++ b/includes/dhcp.php
@@ -15,13 +15,9 @@ function DisplayDHCPConfig()
     $status = new StatusMessage();
     $dhcpcd = new DhcpcdManager();
     $wifi = new WiFiManager();
-    $wifi->getWifiInterface();
 
-    if (!RASPI_MONITOR_ENABLED) {
-        if (isset($_POST['savedhcpdsettings'])) {
-            saveDHCPConfig($status);
-        }
-    }
+    \RaspAP\UI\LiveForm::loadStatusMessages($status);
+    $wifi->getWifiInterface();
 
     exec("ip -o link show | awk -F': ' '{print $2}'", $ifaces);
 
@@ -33,47 +29,6 @@ function DisplayDHCPConfig()
 
     exec('pidof dnsmasq | wc -l', $dnsmasq);
     $dnsmasq_state = ($dnsmasq[0] > 0);
-
-    // handle service control actions
-    if (!RASPI_MONITOR_ENABLED) {
-        if (isset($_POST['startdhcpd'])) {
-            if ($dnsmasq_state) {
-                $status->addMessage('dnsmasq already running', 'info');
-            } else {
-                exec('sudo /bin/systemctl start dnsmasq.service', $dnsmasq, $return);
-                if ($return == 0) {
-                    $status->addMessage('Successfully started dnsmasq', 'success');
-                    $dnsmasq_state = true;
-                } else {
-                    $status->addMessage('Failed to start dnsmasq', 'danger');
-                }
-            }
-        } elseif (isset($_POST['restartdhcpd'])) {
-            if ($dnsmasq_state) {
-                exec('sudo /bin/systemctl restart dnsmasq.service', $dnsmasq, $return);
-                if ($return == 0) {
-                    $status->addMessage('Successfully restarted dnsmasq', 'success');
-                    $dnsmasq_state = false;
-                } else {
-                    $status->addMessage('Failed to restart dnsmasq', 'danger');
-                }
-            } else {
-                $status->addMessage('dnsmasq already stopped', 'info');
-            }
-        } elseif (isset($_POST['stopdhcpd'])) {
-            if ($dnsmasq_state) {
-                exec('sudo /bin/systemctl stop dnsmasq.service', $dnsmasq, $return);
-                if ($return == 0) {
-                    $status->addMessage('Successfully stopped dnsmasq', 'success');
-                    $dnsmasq_state = false;
-                } else {
-                    $status->addMessage('Failed to stop dnsmasq', 'danger');
-                }
-            } else {
-                $status->addMessage('dnsmasq already stopped', 'info');
-            }
-        }
-    }
     
     $ap_iface = $_SESSION['ap_interface'];
     $initial_iface = isset($_POST['interface']) ? $_POST['interface'] : $ap_iface;

--- a/includes/hostapd.php
+++ b/includes/hostapd.php
@@ -16,7 +16,7 @@ $wifi->getWifiInterface();
  */
 function DisplayHostAPDConfig()
 {
-    $reg_domain = 'GB';
+    
     $hostapd = new HostapdManager();
     $hotspot = new HotspotService();
     $status = new StatusMessage();
@@ -24,102 +24,42 @@ function DisplayHostAPDConfig()
     $system = new Sysinfo();
     $operatingSystem = $system->operatingSystem();
 
+    \RaspAP\UI\LiveForm::loadStatusMessages($status);
+
+    $interface = $_SESSION['ap_interface'];
+
     // set hostapd defaults
     $arr80211Standard = $hotspot->get80211Standards();
     $arrSecurity = $hotspot->getSecurityModes();
     $arrEncType = $hotspot->getEncTypes();
     $arr80211w = $hotspot->get80211wOptions();
+    $ifaces = $hotspot->getInterfaces();
+    
+    // get current hostapd config
+    $arrHostapdConf = $hotspot->getHostapdIni();
+    
+    // get country codes for select input and set default reg domain
     $languageCode = strtok($_SESSION['locale'], '_');
     $countryCodes = getCountryCodes($languageCode);
-    $ifaces = $hotspot->getInterfaces();
-    $interfaces = [];
-    foreach ($ifaces as $iface) {
-        $ifaceServices = [];
-        if ($iface === $_SESSION['ap_interface']) {
-            $ifaceServices[] = 'AP';
-        }
-        if ($iface === $_SESSION['wifi_client_interface']) {
-            $ifaceServices[] = 'Client';
-        }
-        $label = !empty($ifaceServices) ? $iface . ' (' . implode(', ', $ifaceServices) . ')' : $iface;
-        $interfaces[$iface] = $label;
-    }
-    $arrTxPower = getDefaultNetOpts('txpower','dbm');
-    $managedModeEnabled = false;
+    $reg_domain = 'GB';
     try {
         $reg_domain = $hotspot->getRegDomain();
     } catch (RuntimeException $e) {
         error_log('Failed to get regulatory domain: ' . $e->getMessage());
     }
-
-    if (isset($_POST['interface'])) {
-        $interface = $_POST['interface'];
-    } else {
-        $interface = $_SESSION['ap_interface'];
-    }
-
+        
+    // get current txpower settings and select options
     $txpower = $hotspot->getTxPower($interface);
-    $arrHostapdConf = $hotspot->getHostapdIni();
-    $logOutput = [];
-
-    if (!RASPI_MONITOR_ENABLED) {
-        if (isset($_POST['StartHotspot']) || isset($_POST['RestartHotspot'])) {
-            $status->addMessage('Attempting to start hotspot', 'info');
-            if ($arrHostapdConf['BridgedEnable'] == 1) {
-                exec('sudo '.RASPI_CONFIG.'/hostapd/servicestart.sh --interface br0 --seconds 1', $return);
-            } elseif ($arrHostapdConf['WifiAPEnable'] == 1) {
-                exec('sudo '.RASPI_CONFIG.'/hostapd/servicestart.sh --interface uap0 --seconds 1', $return);
-            } else {
-                // systemctl expects a unit name like raspap-network-activity@wlan0.service
-                $iface_nonescaped = $interface;
-                if (preg_match('/^[a-zA-Z0-9_-]+$/', $iface_nonescaped)) { // validate interface name
-                    exec('sudo '.RASPI_CONFIG.'/hostapd/servicestart.sh --interface ' .$iface_nonescaped. ' --seconds 1', $return);
-                } else {
-                    throw new \Exception('Invalid network interface');
-                }
-            }
-            foreach ($return as $line) {
-                $status->addMessage($line, 'info');
-            }
-        } elseif (isset($_POST['SaveHostAPDSettings'])) {
-            $result = $hotspot->saveSettings(
-                $_POST,
-                $arrSecurity,
-                $arrEncType,
-                $arr80211Standard,
-                $ifaces,
-                $reg_domain,
-                $status
-            );
-
-            // reload hostapi.ini
-            $arrHostapdConf = $hotspot->getHostapdIni();
-
-        } elseif (isset($_POST['StopHotspot'])) {
-            $status->addMessage('Attempting to stop hotspot', 'info');
-            exec('sudo /bin/systemctl stop hostapd.service', $return);
-            exec('sudo systemctl stop "raspap-network-activity@*.service"');
-            foreach ($return as $line) {
-                $status->addMessage($line, 'info');
-            }
-        }
-    }
+    $arrTxPower = getDefaultNetOpts('txpower','dbm');
+    
+    // check if wifi client interface is connected to a network
+    // used conditionally enables toggles
+    $managedModeEnabled = false;
     if (isset($_SESSION['wifi_client_interface'])) {
         exec('iwgetid '.escapeshellarg($_SESSION['wifi_client_interface']). ' -r', $wifiNetworkID);
         if (!empty($wifiNetworkID[0])) {
             $managedModeEnabled = true;
         }
-    }
-
-    // process txpower user input 
-    if (isset($_POST['txpower'])) {
-        if ($_POST['txpower'] != 'auto') {
-            $txpower = intval($_POST['txpower']);
-            $hotspot->maybeSetTxPower($interface, $txpower, $status);
-        } elseif ($_POST['txpower'] == 'auto') {
-            $hotspot->maybeSetTxPower($interface, 'auto', $status);
-        }
-        $txpower = $_POST['txpower'];
     }
 
     // parse hostapd configuration
@@ -154,6 +94,7 @@ function DisplayHostAPDConfig()
     }
 
     // fetch hostapd logs if enabled
+    $logOutput = [];
     if ((string)$arrHostapdConf['LogEnable'] === "1") {
         $logResult = $hotspot->getHostapdLogs(5000);
         if ($logResult['success']) {
@@ -167,6 +108,19 @@ function DisplayHostAPDConfig()
     $arrConfig['disassoc_low_ack_bool'] = isset($arrConfig['disassoc_low_ack']) ? 1 : 0;
     $hostapdstatus = $system->hostapdStatus();
     $serviceStatus = $hostapdstatus[0] == 0 ? "down" : "up";
+
+    $interfaces = [];
+    foreach ($ifaces as $iface) {
+        $ifaceServices = [];
+        if ($iface === $_SESSION['ap_interface']) {
+            $ifaceServices[] = 'AP';
+        }
+        if ($iface === $_SESSION['wifi_client_interface']) {
+            $ifaceServices[] = 'Client';
+        }
+        $label = !empty($ifaceServices) ? $iface . ' (' . implode(', ', $ifaceServices) . ')' : $iface;
+        $interfaces[$iface] = $label;
+    }
 
     echo renderTemplate(
         "hostapd", compact(

--- a/includes/openvpn.php
+++ b/includes/openvpn.php
@@ -3,6 +3,8 @@
 require_once 'includes/config.php';
 
 use RaspAP\Networking\Hotspot\WiFiManager;
+use function get_public_ip;
+
 $wifi = new WiFiManager();
 $wifi->getWifiInterface();
 
@@ -12,33 +14,8 @@ $wifi->getWifiInterface();
 function DisplayOpenVPNConfig()
 {
     $status = new \RaspAP\Messages\StatusMessage;
-    if (!RASPI_MONITOR_ENABLED) {
-        if (isset($_POST['SaveOpenVPNSettings'])) {
-            if (isset($_POST['authUser'])) {
-                $authUser = strip_tags(trim($_POST['authUser']));
-            }
-            if (isset($_POST['authPassword'])) {
-                $authPassword = strip_tags(trim($_POST['authPassword']));
-            }
-            if (is_uploaded_file( $_FILES["customFile"]["tmp_name"])) {
-                $return = SaveOpenVPNConfig($status, $_FILES['customFile'], $authUser, $authPassword);
-            }
-        } elseif (isset($_POST['StartOpenVPN'])) {
-            $status->addMessage('Attempting to start OpenVPN', 'info');
-            exec('sudo /bin/systemctl start openvpn-client@client', $return);
-            exec('sudo /bin/systemctl enable openvpn-client@client', $return);
-            foreach ($return as $line) {
-                $status->addMessage($line, 'info');
-            }
-        } elseif (isset($_POST['StopOpenVPN'])) {
-            $status->addMessage('Attempting to stop OpenVPN', 'info');
-            exec('sudo /bin/systemctl stop openvpn-client@client', $return);
-            exec('sudo /bin/systemctl disable openvpn-client@client', $return);
-            foreach ($return as $line) {
-                $status->addMessage($line, 'info');
-            }
-        }
-    }
+
+    \RaspAP\UI\LiveForm::loadStatusMessages($status);
 
     exec('pidof openvpn', $openvpnstatus, $ovpn_return);
     $serviceStatus = ($ovpn_return === 0) ? "up" : "down";
@@ -56,14 +33,8 @@ function DisplayOpenVPNConfig()
     $conf_default =  empty($ret) ? "none" : $ret[0];
 
     $logEnable = 0;
-    if (!empty($_POST) && !isset($_POST['log-openvpn'])) {
-        $logOutput = "";
-        $f = @fopen("/tmp/openvpn.log", "r+");
-        if ($f !== false) {
-            ftruncate($f, 0);
-            fclose($f);
-        }
-    } elseif (isset($_POST['log-openvpn']) || filesize('/tmp/openvpn.log') >0) {
+    $logOutput = "";
+    if (file_exists('/tmp/openvpn.log') && filesize('/tmp/openvpn.log') > 0) {
         $logEnable = 1;
         exec("sudo /etc/raspap/openvpn/openvpnlog.sh", $logOutput);
         $logOutput = file_get_contents('/tmp/openvpn.log');
@@ -73,7 +44,6 @@ function DisplayOpenVPNConfig()
         "openvpn", compact(
             "status",
             "serviceStatus",
-            "openvpnstatus",
             "logEnable",
             "logOutput",
             "public_ip",

--- a/includes/openvpn.php
+++ b/includes/openvpn.php
@@ -3,7 +3,6 @@
 require_once 'includes/config.php';
 
 use RaspAP\Networking\Hotspot\WiFiManager;
-use function get_public_ip;
 
 $wifi = new WiFiManager();
 $wifi->getWifiInterface();

--- a/includes/wireguard.php
+++ b/includes/wireguard.php
@@ -14,36 +14,8 @@ function DisplayWireGuardConfig()
 {
     $parseFlag = true;
     $status = new \RaspAP\Messages\StatusMessage;
-    if (!RASPI_MONITOR_ENABLED) {
-        $optRules     = isset($_POST['wgRules']) ? $_POST['wgRules'] : null;
-        $optInterface = isset($_POST['wgInterface']) ? $_POST['wgInterface'] : null;
-        $optConf      = isset($_POST['wgCnfOpt']) ? $_POST['wgCnfOpt'] : null;
-        $optSrvEnable = isset($_POST['wgSrvEnable']) ? $_POST['wgSrvEnable'] : null;
-        $optLogEnable = isset($_POST['wgLogEnable']) ? $_POST['wgLogEnable'] : null;
-        $optKSwitch   = isset($_POST['wgKSwitch']) ? $_POST['wgKSwitch'] : null;
-        if (isset($_POST['savewgsettings']) && $optConf == 'manual' && $optSrvEnable == 1 ) {
-            SaveWireGuardConfig($status);
-        } elseif (isset($_POST['savewgsettings']) && $optConf == 'upload' && is_uploaded_file($_FILES["wgFile"]["tmp_name"])) {
-            SaveWireGuardUpload($status, $_FILES['wgFile'], $optRules, $optKSwitch, $optInterface);
-        } elseif (isset($_POST['savewgsettings']) && isset($_POST['wg_penabled']) ) {
-            SaveWireGuardConfig($status);
-        } elseif (isset($_POST['startwg'])) {
-            $status->addMessage('Attempting to start WireGuard', 'info');
-            exec('sudo /bin/systemctl enable wg-quick@wg0', $return);
-            exec('sudo /bin/systemctl start wg-quick@wg0', $return);
-            foreach ($return as $line) {
-                $status->addMessage($line, 'info');
-            }
-        } elseif (isset($_POST['stopwg'])) {
-            $status->addMessage('Attempting to stop WireGuard', 'info');
-            exec('sudo /bin/systemctl stop wg-quick@wg0', $return);
-            exec('sudo /bin/systemctl disable wg-quick@wg0', $return);
-            foreach ($return as $line) {
-                $status->addMessage($line, 'info');
-            }
-        }
-        CheckWireGuardLog( $optLogEnable, $status );
-    }
+
+    \RaspAP\UI\LiveForm::loadStatusMessages($status);
 
     // fetch server config
     exec('sudo cat '. RASPI_WIREGUARD_CONFIG, $return);
@@ -58,7 +30,7 @@ function DisplayWireGuardConfig()
         $wg_srvdns = implode(', ', $wg_srvdns);
     }
     $wg_peerpubkey = exec('sudo cat '. RASPI_WIREGUARD_PATH .'wg-peer-public.key', $return);
-    if (sizeof($conf) >0) {
+    if (sizeof($conf) > 0) {
         $wg_senabled = true;
     }
 
@@ -70,7 +42,8 @@ function DisplayWireGuardConfig()
     $wg_pendpoint = ($conf['Endpoint'] == '') ? getDefaultNetValue('wireguard','peer','Endpoint') : $conf['Endpoint'];
     $wg_pallowedips = ($conf['AllowedIPs'] == '') ? getDefaultNetValue('wireguard','peer','AllowedIPs') : $conf['AllowedIPs'];
     $wg_pkeepalive = ($conf['PersistentKeepalive'] == '') ? getDefaultNetValue('wireguard','peer','PersistentKeepalive') : $conf['PersistentKeepalive'];
-    if (sizeof($conf) >0) {
+    $wg_penabled = false;
+    if (sizeof($conf) > 0) {
         $wg_penabled = true;
     }
 
@@ -88,10 +61,11 @@ function DisplayWireGuardConfig()
 
     // fetch wg log
     exec('sudo chmod o+r /tmp/wireguard.log');
-    if (file_exists('/tmp/wireguard.log')) {
+    $log = '';
+    $optLogEnable = 0;
+    if (file_exists('/tmp/wireguard.log') && filesize('/tmp/wireguard.log') > 0) {
+        $optLogEnable = 1;
         $log = file_get_contents('/tmp/wireguard.log');
-    } else {
-        $log = '';
     }
     $peer_id = $peer_id ?? "1";
 
@@ -106,8 +80,6 @@ function DisplayWireGuardConfig()
             "serviceStatus",
             "public_ip",
             "interfaces",
-            "optRules",
-            "optKSwitch",
             "optLogEnable",
             "peer_id",
             "wg_srvpubkey",
@@ -128,262 +100,3 @@ function DisplayWireGuardConfig()
         )
     );
 }
-
-/**
- * Validates uploaded .conf file, adds iptables post-up and
- * post-down rules.
- *
- * @param  object $status
- * @param  object $file
- * @param  boolean $optRules
- * @param  boolean $optKSwitch
- * @param  string $optInterface
- * @return object $status
- */
-function SaveWireGuardUpload($status, $file, $optRules, $optKSwitch, $optInterface)
-{
-    define('KB', 1024);
-    $tmp_destdir = '/tmp/';
-    $auth_flag = 0;
-
-    try {
-        // If undefined or multiple files, treat as invalid
-        if (!isset($file['error']) || is_array($file['error'])) {
-            throw new RuntimeException('Invalid parameters');
-        }
-
-        $upload = \RaspAP\Uploader\FileUpload::factory('wg',$tmp_destdir);
-        $upload->set_max_file_size(64*KB);
-        $upload->set_allowed_mime_types(array('text/plain'));
-        $upload->file($file);
-
-        $validation = new validation;
-        $upload->callbacks($validation, array('check_name_length'));
-        $results = $upload->upload();
-
-        if (!empty($results['errors'])) {
-            throw new RuntimeException($results['errors'][0]);
-        }
-
-        // Valid upload, get file contents
-        $tmp_wgconfig = $results['full_path'];
-        $tmp_contents = file_get_contents($tmp_wgconfig);
-
-        // Check for existing iptables rules
-        if ((isset($optRules) || isset($optKSwitch)) && preg_match('/PostUp|PostDown|PreDown/m',$tmp_contents)) {
-            $status->addMessage('Existing iptables rules found in WireGuard configuration - not added', 'info');
-        } else {
-            // Set rules from default config
-            if (isset($optRules)) {
-                $rules[] = 'PostUp = '.getDefaultNetValue('wireguard','server','PostUp');
-                $rules[] = 'PostDown = '.getDefaultNetValue('wireguard','server','PostDown');
-                $rules = preg_replace('/wlan0/m', $optInterface, $rules);
-            }
-            if (isset($optKSwitch)) {
-                // Get ap static ip_addr from system config, fallback to default if undefined
-                $jsonData = json_decode(getNetConfig($optInterface), true);
-                $ip_addr = ($jsonData['StaticIP'] == '') ? getDefaultNetValue('dhcp', $optInterface, 'static ip_address') : $jsonData['StaticIP'];
-                $mask = ($jsonData['SubnetMask'] == '') ? getDefaultNetValue('dhcp', $optInterface, 'subnetmask') : $jsonData['SubnetMask'];
-
-                // if empty, try to detect IP/mask from system
-                if (empty($ip_addr) || empty($mask)) {
-                    $ipDetails = shell_exec("ip -4 -o addr show dev " . escapeshellarg($optInterface));
-                    if (preg_match('/inet (\d+\.\d+\.\d+\.\d+)\/(\d+)/', $ipDetails, $matches)) {
-                        $ip_addr = $matches[1];
-                        $cidr = $matches[2];
-                    } else {
-                        $ip_addr = '0.0.0.0';
-                        $cidr = '24';
-                    }
-                } else {
-                    $cidr = mask2cidr($mask);
-                }
-                $cidr_ip = strpos($ip_addr, '/') === false ? "$ip_addr/$cidr" : $ip_addr;
-
-                $rules[] = 'PostUp = '.getDefaultNetValue('wireguard','server','PostUpEx');
-                $rules[] = 'PreDown = '.getDefaultNetValue('wireguard','server','PreDown');
-                $rules = preg_replace('/%s/m', $cidr_ip, $rules);
-            }
-            if ((isset($rules) && count($rules) > 0)) {
-                $rules[] = '';
-                $rules = join(PHP_EOL, $rules);
-                $tmp_contents = preg_replace('/^\s*$/ms', $rules, $tmp_contents, 1);
-                file_put_contents($tmp_wgconfig, $tmp_contents);
-                $status->addMessage('iptables rules added to WireGuard configuration', 'info');
-            }
-        }
-
-        // Move processed file from /tmp and create symlink
-        $client_wg = RASPI_WIREGUARD_PATH.pathinfo($file['name'], PATHINFO_FILENAME).'.conf';
-        chmod($tmp_wgconfig, 0644);
-        system("sudo mv $tmp_wgconfig $client_wg", $return);
-        system("sudo rm ".RASPI_WIREGUARD_CONFIG, $return);
-        system("sudo ln -s $client_wg ".RASPI_WIREGUARD_CONFIG, $return);
-
-        if ($return ==0) {
-            $status->addMessage('WireGuard configuration uploaded successfully', 'info');
-        } else {
-            $status->addMessage('Unable to save WireGuard configuration', 'danger');
-        }
-        return $status;
-
-    } catch (RuntimeException $e) {
-        $status->addMessage($e->getMessage(), 'danger');
-        return $status;
-    }
-}
-
-/**
- * Validate user input, save wireguard configuration
- *
- * @param object $status
- * @return boolean
- */
-function SaveWireGuardConfig($status)
-{
-    // Set defaults
-    $good_input = true;
-    $peer_id = 1;
-    // Validate server input
-    if ($_POST['wgSrvEnable'] == 1) {
-        if (isset($_POST['wg_srvport'])) {
-            if (strlen($_POST['wg_srvport']) > 5 || !is_numeric($_POST['wg_srvport'])) {
-                $status->addMessage('Invalid value for server local port', 'danger');
-                $good_input = false;
-            }
-        }
-        if (isset($_POST['wg_plistenport'])) {
-            if (strlen($_POST['wg_plistenport']) > 5 || !is_numeric($_POST['wg_plistenport'])) {
-                $status->addMessage('Invalid value for peer local port', 'danger');
-                $good_input = false;
-            }
-        }
-        if (isset($_POST['wg_srvipaddress'])) {
-            if (!validateCidr($_POST['wg_srvipaddress'])) {
-                $status->addMessage('Invalid value for server IP address', 'danger');
-                $good_input = false;
-            }
-        }
-        if (isset($_POST['wg_srvdns'])) {
-            if (!filter_var($_POST['wg_srvdns'],FILTER_VALIDATE_IP)) {
-                $status->addMessage('Invalid value for DNS', 'danger');
-                $good_input = false;
-            }
-        }
-    }
-    // Validate peer input
-    if ($_POST['wg_penabled'] == 1) {
-        if (isset($_POST['wg_pipaddress'])) {
-            if (!validateCidr($_POST['wg_pipaddress'])) {
-                $status->addMessage('Invalid value for peer IP address', 'danger');
-                $good_input = false;
-            }
-        }
-        if (isset($_POST['wg_pendpoint']) && strlen(trim($_POST['wg_pendpoint']) >0 )) {
-            $wg_pendpoint_seg = substr($_POST['wg_pendpoint'],0,strpos($_POST['wg_pendpoint'],':'));
-            $host_port = explode(':', $wg_pendpoint_seg);
-            $hostname = $host_port[0];
-            if (!filter_var($hostname, FILTER_VALIDATE_IP) &&
-                !filter_var($hostname, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)) {
-                $status->addMessage('Invalid value for endpoint address', 'danger');
-                $good_input = false;
-            }
-        }
-        if (isset($_POST['wg_pallowedips']) && strlen(trim($_POST['wg_pallowedips']) >0)) {
-            if (!validateCidr($_POST['wg_pallowedips'])) {
-                $status->addMessage('Invalid value for allowed IPs', 'danger');
-                $good_input = false;
-            }
-        }
-        if (isset($_POST['wg_pkeepalive']) && strlen(trim($_POST['wg_pkeepalive']) >0 )) {
-            if (strlen($_POST['wg_pkeepalive']) > 4 || !is_numeric($_POST['wg_pkeepalive'])) {
-                $status->addMessage('Invalid value for persistent keepalive', 'danger');
-                $good_input = false;
-            }
-        }
-    }
-
-    // Save settings
-    if ($good_input) {
-        // server (wg0.conf)
-        if ($_POST['wgSrvEnable'] == 1) {
-            // fetch server private key from filesytem
-            $wg_srvprivkey = exec('sudo cat '. RASPI_WIREGUARD_PATH .'wg-server-private.key', $return);
-            $config[] = '[Interface]';
-            $config[] = 'Address = '.$_POST['wg_srvipaddress'];
-            $config[] = 'ListenPort = '.$_POST['wg_srvport'];
-            $config[] = 'DNS = '.$_POST['wg_srvdns'];
-            $config[] = 'PrivateKey = '.$wg_srvprivkey;
-            $config[] = 'PostUp = '.getDefaultNetValue('wireguard','server','PostUp');
-            $config[] = 'PostDown = '.getDefaultNetValue('wireguard','server','PostDown');
-            $config[] = '';
-            $config[] = '[Peer]';
-            $config[] = 'PublicKey = '.$_POST['wg-peer'];
-            $config[] = 'AllowedIPs = '.$_POST['wg_pallowedips'];
-            if ($_POST['wg_pkeepalive'] !== '') {
-                $config[] = 'PersistentKeepalive = '.trim($_POST['wg_pkeepalive']);
-            }
-            $config[] = '';
-            $config = join(PHP_EOL, $config);
-
-            file_put_contents("/tmp/wgdata", $config);
-            system('sudo cp /tmp/wgdata '.RASPI_WIREGUARD_CONFIG, $return);
-        } else {
-            # remove selected conf + keys
-            system('sudo rm '. RASPI_WIREGUARD_PATH .'wg-server-private.key', $return);
-            system('sudo rm '. RASPI_WIREGUARD_PATH .'wg-server-public.key', $return);
-            system('sudo rm '. RASPI_WIREGUARD_CONFIG, $return);
-        }
-        // client1 (client.conf)
-        if ($_POST['wg_penabled'] == 1) {
-            // fetch peer private key from filesystem 
-            $wg_peerprivkey = exec('sudo cat '. RASPI_WIREGUARD_PATH .'wg-peer-private.key', $return);
-            $config = [];
-            $config[] = '[Interface]';
-            $config[] = 'Address = '.trim($_POST['wg_pipaddress']);
-            $config[] = 'PrivateKey = '.$wg_peerprivkey;
-            $config[] = 'ListenPort = '.$_POST['wg_plistenport'];
-            $config[] = '';
-            $config[] = '[Peer]';
-            $config[] = 'PublicKey = '.$_POST['wg-server'];
-            $config[] = 'AllowedIPs = '.$_POST['wg_pallowedips'];
-            $config[] = 'Endpoint = '.$_POST['wg_pendpoint'];
-            if ($_POST['wg_pkeepalive'] !== '') {
-                $config[] = 'PersistentKeepalive = '.trim($_POST['wg_pkeepalive']);
-            }
-            $config[] = '';
-            $config = join(PHP_EOL, $config);
-            file_put_contents("/tmp/wgdata", $config);
-            system('sudo cp /tmp/wgdata '.RASPI_WIREGUARD_PATH.'client.conf', $return);
-        } else {
-            # remove selected conf + keys
-            system('sudo rm '. RASPI_WIREGUARD_PATH .'wg-peer-private.key', $return);
-            system('sudo rm '. RASPI_WIREGUARD_PATH .'wg-peer-public.key', $return);
-            system('sudo rm '. RASPI_WIREGUARD_PATH.'client.conf', $return);
-        }
-
-        foreach ($return as $line) {
-            $status->addMessage($line, 'info');
-        }
-        if ($return == 0) {
-            $status->addMessage('WireGuard configuration updated successfully', 'success');
-        } else {
-            $status->addMessage('WireGuard configuration failed to be updated', 'danger');
-        }
-    }
-}
-
-/**
- *
- * @return object $status
- */
-function CheckWireGuardLog( $opt, $status )
-{
-   // handle log option
-    if ( $opt == "1") {
-        exec("sudo journalctl --identifier wg-quick > /tmp/wireguard.log");
-        $status->addMessage('WireGuard debug log updated', 'success');
-    }
-    return $status;
-}
-

--- a/index.php
+++ b/index.php
@@ -147,9 +147,9 @@ initializeApp();
               ></div>
             </div>
 
-            <div class="d-flex justify-content-between align-items-center mb-2">
-              <span id="liveFormModalCurrentMessage"></span>
-              <button class="btn btn-sm btn-outline-primary"
+            <div class="d-flex justify-content-between align-items-center gap-2 mb-2">
+              <span id="liveFormModalCurrentMessage" class="flex-grow-1 text-nowrap overflow-hidden"></span>
+              <button class="btn btn-sm btn-outline-primary text-nowrap"
                   type="button"
                   data-bs-toggle="collapse"
                   data-bs-target="#liveFormModalCollapse"

--- a/index.php
+++ b/index.php
@@ -128,6 +128,51 @@ initializeApp();
         </footer>
       </div>
     </div>
+
+    <div id="liveFormModal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="liveFormModalTitle" aria-hidden="true"
+      data-bs-backdrop="static" data-bs-keyboard="false">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content" style="height: 100%;">
+          <div class="modal-header">
+              <div class="modal-title" id="liveFormModalTitle">Submitting Live Form</div>
+          </div>
+
+          <div class="modal-body">
+            <div class="progress mb-3" style="height: 20px;">
+              <div id="liveFormModalProgressBar"
+                class="progress-bar progress-bar-striped progress-bar-animated"
+                role="progressbar"
+                aria-valuemin="0"
+                aria-valuemax="100"
+              ></div>
+            </div>
+
+            <div class="d-flex justify-content-between align-items-center mb-2">
+              <span id="liveFormModalCurrentMessage"></span>
+              <button class="btn btn-sm btn-outline-primary"
+                  type="button"
+                  data-bs-toggle="collapse"
+                  data-bs-target="#liveFormModalCollapse"
+                  aria-expanded="false"
+                  aria-controls="liveFormModalCollapse"
+                >
+                Show Details
+              </button>
+            </div>
+
+            <div id="liveFormModalCollapse" class="collapse">
+              <div class="card card-body">
+                <pre id="liveFormModalMessageHistory" class="mb-0" style="height: 100px; overflow: auto;"></pre>
+              </div>
+            </div>
+          </div>
+
+          <!-- <div class="modal-footer">
+          </div> -->
+        </div>
+      </div>
+    </div>
+
     <?php ob_end_flush(); ?>
     <!-- jQuery -->
     <script src="dist/jquery/jquery.min.js?v=<?= filemtime('dist/jquery/jquery.min.js'); ?>"></script>

--- a/index.php
+++ b/index.php
@@ -148,7 +148,7 @@ initializeApp();
             </div>
 
             <div class="d-flex justify-content-between align-items-center gap-2 mb-2">
-              <span id="liveFormModalCurrentMessage" class="flex-grow-1 text-nowrap overflow-hidden"></span>
+              <span id="liveFormModalCurrentMessage" class="flex-grow-1"></span>
               <button class="btn btn-sm btn-outline-primary text-nowrap"
                   type="button"
                   data-bs-toggle="collapse"

--- a/index.php
+++ b/index.php
@@ -167,8 +167,7 @@ initializeApp();
             </div>
           </div>
 
-          <!-- <div class="modal-footer">
-          </div> -->
+          <div class="modal-footer" style="display: none;"></div>
         </div>
       </div>
     </div>

--- a/src/RaspAP/Messages/StatusMessage.php
+++ b/src/RaspAP/Messages/StatusMessage.php
@@ -20,7 +20,7 @@ class StatusMessage
         if ($dismissable) {
             $status .= ' alert-dismissible';
         }
-        $status .= ' fade show" role="alert">'. _($message);
+        $status .= ' fade show" role="alert">'. $message;
         if ($dismissable) {
             $status .= '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="close"></button>';
         }

--- a/src/RaspAP/Networking/Hotspot/DhcpcdManager.php
+++ b/src/RaspAP/Networking/Hotspot/DhcpcdManager.php
@@ -12,8 +12,6 @@ declare(strict_types=1);
 
 namespace RaspAP\Networking\Hotspot;
 
-require_once __DIR__ . '/../../../../includes/functions.php';
-
 use RaspAP\Messages\StatusMessage;
 use function mask2cidr;
 

--- a/src/RaspAP/Networking/Hotspot/DhcpcdManager.php
+++ b/src/RaspAP/Networking/Hotspot/DhcpcdManager.php
@@ -14,6 +14,8 @@ namespace RaspAP\Networking\Hotspot;
 
 use RaspAP\Messages\StatusMessage;
 use function mask2cidr;
+use function getDefaultNetOpts;
+use function getDefaultNetValue;
 
 class DhcpcdManager
 {

--- a/src/RaspAP/Networking/Hotspot/DhcpcdManager.php
+++ b/src/RaspAP/Networking/Hotspot/DhcpcdManager.php
@@ -79,7 +79,7 @@ class DhcpcdManager
                 'static routers=' . $routers,
                 'static domain_name_servers=' . $domain_name_servers
             ];
-            $client_metric = getIfaceMetric($_SESSION['wifi_client_interface']);
+            $client_metric = $this->getIfaceMetric($_SESSION['wifi_client_interface']);
             if (is_int($client_metric)) {
                 $config[] = 'metric ' . ((int)$client_metric + 1);
             } else {

--- a/src/RaspAP/Networking/Hotspot/DhcpcdManager.php
+++ b/src/RaspAP/Networking/Hotspot/DhcpcdManager.php
@@ -12,7 +12,10 @@ declare(strict_types=1);
 
 namespace RaspAP\Networking\Hotspot;
 
+require_once __DIR__ . '/../../../../includes/functions.php';
+
 use RaspAP\Messages\StatusMessage;
+use function mask2cidr;
 
 class DhcpcdManager
 {

--- a/src/RaspAP/Networking/Hotspot/DnsmasqManager.php
+++ b/src/RaspAP/Networking/Hotspot/DnsmasqManager.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 namespace RaspAP\Networking\Hotspot;
 
 use RaspAP\Messages\StatusMessage;
+use function getDefaultNetValue;
+use function validateMac;
 
 class DnsmasqManager
 {

--- a/src/RaspAP/Networking/Hotspot/HostapdManager.php
+++ b/src/RaspAP/Networking/Hotspot/HostapdManager.php
@@ -14,6 +14,7 @@ namespace RaspAP\Networking\Hotspot;
 
 use RaspAP\Networking\Hotspot\Validators\HostapdValidator;
 use RaspAP\Messages\StatusMessage;
+use function getDefaultNetOpts;
 
 class HostapdManager
 {

--- a/src/RaspAP/Networking/Hotspot/HotspotService.php
+++ b/src/RaspAP/Networking/Hotspot/HotspotService.php
@@ -19,6 +19,7 @@ namespace RaspAP\Networking\Hotspot;
 
 use RaspAP\Networking\Hotspot\Validators\HostapdValidator;
 use RaspAP\Messages\StatusMessage;
+use function validateInterface;
 
 class HotspotService
 {

--- a/src/RaspAP/Networking/Hotspot/WiFiManager.php
+++ b/src/RaspAP/Networking/Hotspot/WiFiManager.php
@@ -11,8 +11,6 @@ declare(strict_types=1);
 
 namespace RaspAP\Networking\Hotspot;
 
-require_once __DIR__ . '/../../../../includes/functions.php';
-
 use function validateInterface;
 
 class WiFiManager

--- a/src/RaspAP/Networking/Hotspot/WiFiManager.php
+++ b/src/RaspAP/Networking/Hotspot/WiFiManager.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace RaspAP\Networking\Hotspot;
 
 use function validateInterface;
+use function ConvertToChannel;
 
 class WiFiManager
 {

--- a/src/RaspAP/Networking/Hotspot/WiFiManager.php
+++ b/src/RaspAP/Networking/Hotspot/WiFiManager.php
@@ -11,6 +11,10 @@ declare(strict_types=1);
 
 namespace RaspAP\Networking\Hotspot;
 
+require_once __DIR__ . '/../../../../includes/functions.php';
+
+use function validateInterface;
+
 class WiFiManager
 {
 

--- a/src/RaspAP/UI/LiveForm.php
+++ b/src/RaspAP/UI/LiveForm.php
@@ -96,7 +96,7 @@ class LiveForm
     public function sendUpdateMessage($message, $progress = null) {
         if ($this->status != SELF::RUNNING) $this->status = SELF::RUNNING;
         if ($progress != null) $this->progress = $progress;
-        array_push($this->messageHistory, $message);
+        if ($message != null) array_push($this->messageHistory, $message);
 
         $this->sendMessage($message);
     }

--- a/src/RaspAP/UI/LiveForm.php
+++ b/src/RaspAP/UI/LiveForm.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Live Form Submission
+ *
+ * @description A class providing the backend framework of the live form submission feature
+ * @author      Shawn Holmes <sherlock656@gmail.com>
+ * @license     https://github.com/raspap/raspap-webgui/blob/master/LICENSE
+ */
+
+namespace RaspAP\UI;
+
+class LiveForm
+{
+    public const SESSION_STATUS_MESSAGES = 'liveFormStatusMessages';
+
+    // statuses
+    public const START = 'START';
+    public const RUNNING = 'RUNNING';
+    public const FAILED = 'FAILED';
+    public const COMPLETE = 'COMPLETE';
+
+    protected $status = 'INIT';
+    protected $progress = 0;
+    protected $messageHistory = [];
+
+    // used to enforce a min processing time to make
+    // sure the frontend doesn't show to quick
+    private $start_time;
+    private $end_time;
+    protected const MIN_PROC_TIME = 3.0;
+
+    /**
+     * Use this function to initialize the ajax live form file
+     */
+    public function initAjax() {
+        header('Content-Type: text/event-stream');
+        header('Cache-Control: no-cache');
+
+        ini_set('zlib.output_compression', 'Off');
+        ini_set('output_buffering', '0');
+        ob_implicit_flush(true);
+        while (ob_get_level() > 0) ob_end_flush();
+    }
+
+    /**
+     * This function should be run early on to indicate
+     * the start of the stream of information to the frontend
+     */
+    public function sendStartMessage() {
+        $this->status = SELF::START;
+        $this->progress = 0;
+        $this->start_time = microtime(true);
+
+        $this->sendMessage();
+    }
+
+    /**
+     * This function should to indicate to the frontend that a
+     * critical failure occurred. If trying to indicate that portion
+     * of the processing was not successful, use `sendLiveFormMessage` indicating so.
+     */
+    public function sendFailedMessage() {
+        $this->status = SELF::FAILED;
+        $this->progress = 100;
+        $this->checkRuntimeDelay();
+
+        $this->sendMessage();
+        exit;
+    }
+
+    /**
+     * This function should the last to be run to indicate
+     * to the frontend that processing is complete
+     */
+    public function sendCompleteMessage() {
+        $this->status = SELF::COMPLETE;
+        $this->progress = 100;
+        $this->checkRuntimeDelay();
+
+        $this->sendMessage();
+        exit;
+    }
+
+    private function checkRuntimeDelay() {
+        $this->end_time = microtime(true);
+
+        $duration = $this->end_time - $this->start_time;
+        if ($duration < SELF::MIN_PROC_TIME) {
+            sleep(SELF::MIN_PROC_TIME - $duration);
+        }
+    }
+
+    /**
+     * Sends progress update message to the frontend
+     */
+    public function sendUpdateMessage($message, $progress = null) {
+        if ($this->status != SELF::RUNNING) $this->status = SELF::RUNNING;
+        if ($progress != null) $this->progress = $progress;
+        array_push($this->messageHistory, $message);
+
+        $this->sendMessage($message);
+    }
+
+    /**
+     * Save a message to session that will be displayed
+     * on the refresh of the responsible page
+     */
+    public function saveStatusMessage($message, $level, $withHistory = false) {
+        if ($withHistory) {
+            $historyMessage = "<div>$message<button type=\"button\" class=\"btn btn-sm btn-outline-secondary ms-2\" data-bs-toggle=\"collapse\" data-bs-target=\"#liveFromAlertHistory\">Show History</button></div>";
+            $historyMessage .= "<div id=\"liveFromAlertHistory\" class=\"collapse mt-3\"><div class=\"card card-body\"><pre class=\"mb-0\">";
+            foreach ($this->messageHistory as $history) {
+                $historyMessage .= $history . "\n";
+            }
+            $historyMessage .= "</pre></div></div>";
+        }
+
+        $statusMessage = [
+            'message' => $historyMessage ?? $message,
+            'level' => $level
+        ];
+
+        if (!isset($_SESSION[SELF::SESSION_STATUS_MESSAGES])) {
+            $_SESSION[SELF::SESSION_STATUS_MESSAGES] = [];
+        }
+
+        $_SESSION[SELF::SESSION_STATUS_MESSAGES][] = $statusMessage;
+    }
+
+    static function loadStatusMessages($status) {
+        if (isset($_SESSION[SELF::SESSION_STATUS_MESSAGES])) {
+            foreach ($_SESSION[SELF::SESSION_STATUS_MESSAGES] as $statusMessage) {
+                $status->addMessage($statusMessage['message'], $statusMessage['level']);
+            }
+
+            unset($_SESSION['liveFormStatusMessages']);
+        }
+    }
+
+    private function sendMessage($message = null) {
+        $data = [
+            "status" => $this->status,
+            "progress" => $this->progress,
+        ];
+
+        if (isset($message)) {
+            $data['message'] = $message;
+        }
+
+        echo "data: " . json_encode($data) . "\n\n";
+        flush();
+    }
+}

--- a/src/RaspAP/UI/LiveFormStatusMessage.php
+++ b/src/RaspAP/UI/LiveFormStatusMessage.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Live Form Status Message Class
+ *
+ * @description A class to override the functions of the StatusMessage class to send messages to the frontend in real time as a form is being processed.
+ * @author      Shawn Holmes <sherlock656@gmail.com>
+ * @license     https://github.com/raspap/raspap-webgui/blob/master/LICENSE
+ */
+namespace RaspAP\UI;
+
+use RaspAP\Messages\StatusMessage;
+
+class LiveFormStatusMessage extends StatusMessage
+{
+    private $liveForm;
+
+    public function __construct($liveForm) {
+        $this->liveForm = $liveForm;
+    }
+
+    public function addMessage($message, $level = 'success', $dismissable = true) {
+        $this->liveForm->sendUpdateMessage($message);
+    }
+}

--- a/templates/adblock.php
+++ b/templates/adblock.php
@@ -12,7 +12,7 @@
           <div>
             <i class="far fa-hand-paper me-2"></i><?php echo _("Ad Blocking"); ?>
           </div>
-          <form method="POST" action="/ajax/page/adblock.php" class="live-form">
+          <form method="POST" action="/ajax/page/adblock.php" class="live-form" data-modal-title="Ad Block Service Control">
             <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
             <div class="btn-group" role="group">
               <?php if (!RASPI_MONITOR_ENABLED) : ?>
@@ -37,7 +37,7 @@
 
       <div class="card-body">
         <?php $status->showMessages(); ?>
-        <form role="form" action="/ajax/page/adblock.php" enctype="multipart/form-data" method="POST" class="live-form">
+        <form role="form" action="/ajax/page/adblock.php" enctype="multipart/form-data" method="POST" class="live-form" data-modal-title="Saving Adblock Configuration">
           <?php echo \RaspAP\Tokens\CSRF::hiddenField();?>
           <!-- Nav tabs -->
           <ul class="nav nav-tabs">

--- a/templates/adblock.php
+++ b/templates/adblock.php
@@ -12,7 +12,7 @@
           <div>
             <i class="far fa-hand-paper me-2"></i><?php echo _("Ad Blocking"); ?>
           </div>
-          <form method="POST" action="adblock_conf">
+          <form method="POST" action="/ajax/page/adblock.php" class="live-form">
             <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
             <div class="btn-group" role="group">
               <?php if (!RASPI_MONITOR_ENABLED) : ?>
@@ -37,7 +37,7 @@
 
       <div class="card-body">
         <?php $status->showMessages(); ?>
-        <form role="form" action="adblock_conf" enctype="multipart/form-data" method="POST">
+        <form role="form" action="/ajax/page/adblock.php" enctype="multipart/form-data" method="POST" class="live-form">
           <?php echo \RaspAP\Tokens\CSRF::hiddenField();?>
           <!-- Nav tabs -->
           <ul class="nav nav-tabs">

--- a/templates/adblock.php
+++ b/templates/adblock.php
@@ -12,7 +12,7 @@
           <div>
             <i class="far fa-hand-paper me-2"></i><?php echo _("Ad Blocking"); ?>
           </div>
-          <form method="POST" action="/ajax/page/adblock.php" class="live-form" data-modal-title="Ad Block Service Control">
+          <form method="POST" action="/ajax/page/adblock.php" class="live-form" data-modal-title="<?= _('AdBlock Service Control') ?>">
             <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
             <div class="btn-group" role="group">
               <?php if (!RASPI_MONITOR_ENABLED) : ?>
@@ -37,7 +37,7 @@
 
       <div class="card-body">
         <?php $status->showMessages(); ?>
-        <form role="form" action="/ajax/page/adblock.php" enctype="multipart/form-data" method="POST" class="live-form" data-modal-title="Saving Adblock Configuration">
+        <form role="form" action="/ajax/page/adblock.php" enctype="multipart/form-data" method="POST" class="live-form" data-modal-title="<?= _('AdBlock Configuration') ?>">
           <?php echo \RaspAP\Tokens\CSRF::hiddenField();?>
           <!-- Nav tabs -->
           <ul class="nav nav-tabs">

--- a/templates/adblock.php
+++ b/templates/adblock.php
@@ -12,7 +12,7 @@
           <div>
             <i class="far fa-hand-paper me-2"></i><?php echo _("Ad Blocking"); ?>
           </div>
-          <form method="POST" action="/ajax/page/adblock.php" class="live-form" data-modal-title="<?= _('AdBlock Service Control') ?>">
+          <form method="POST" action="/ajax/page/adblock.php" class="live-form" data-modal-title="<?= _('AdBlock Service Control') ?>" inert>
             <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
             <div class="btn-group" role="group">
               <?php if (!RASPI_MONITOR_ENABLED) : ?>
@@ -37,7 +37,7 @@
 
       <div class="card-body">
         <?php $status->showMessages(); ?>
-        <form role="form" action="/ajax/page/adblock.php" enctype="multipart/form-data" method="POST" class="live-form" data-modal-title="<?= _('AdBlock Configuration') ?>">
+        <form role="form" action="/ajax/page/adblock.php" enctype="multipart/form-data" method="POST" class="live-form" data-modal-title="<?= _('AdBlock Configuration') ?>" inert>
           <?php echo \RaspAP\Tokens\CSRF::hiddenField();?>
           <!-- Nav tabs -->
           <ul class="nav nav-tabs">

--- a/templates/configure_client.php
+++ b/templates/configure_client.php
@@ -26,7 +26,7 @@
         </div>
         <div class="row">
           <div class="col-md-6">
-            <form method="POST" action="wpa_conf">
+            <form method="POST" action="/ajax/page/client.php" class="live-form" data-modal-title="<?= _("WiFi Client Interface") ?>">
               <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
               <label for="cbxclientiface"><?php echo _("Interface"); ?></label>
               <div class="input-group">
@@ -36,7 +36,7 @@
             </form>
           </div>
         </div>
-        <form method="POST" action="wpa_conf" name="wpa_conf_form">
+        <form method="POST" action="/ajax/page/client.php" name="wpa_conf_form" class="live-form" data-modal-title="<?= _("Configuring WiFi Client"); ?>">
           <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
           <div class="row" id="wpaConf">
             <div class="col position-relative">
@@ -50,20 +50,3 @@
     </div><!-- /.card -->
   </div><!-- /.col-lg-12 -->
 </div><!-- /.row -->
-
-<!-- Modal -->
-<div class="modal fade" id="configureClientModal" tabindex="-1" role="dialog" aria-labelledby="ModalLabel" aria-hidden="true">
-  <div class="modal-dialog" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-      <div class="modal-title" id="ModalLabel"><i class="fas fa-sync-alt me-2"></i><?php echo _("Configuring WiFi Client"); ?></div>
-      </div>
-      <div class="modal-body">
-        <div class="col-md-12 mb-3 mt-1"><?php echo _("Configuring Wifi Client Interface..."); ?></div>
-      </div>
-      <div class="modal-footer">
-      <button type="button" class="btn btn-outline-primary" data-bs-dismiss="modal"><?php echo _("Close"); ?></button>
-      </div>
-    </div>
-  </div>
-</div>

--- a/templates/configure_client.php
+++ b/templates/configure_client.php
@@ -26,7 +26,7 @@
         </div>
         <div class="row">
           <div class="col-md-6">
-            <form method="POST" action="/ajax/page/client.php" class="live-form" data-modal-title="<?= _("WiFi Client Interface") ?>">
+            <form method="POST" action="/ajax/page/client.php" class="live-form" data-modal-title="<?= _("WiFi Client Interface") ?>" inert>
               <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
               <label for="cbxclientiface"><?php echo _("Interface"); ?></label>
               <div class="input-group">
@@ -36,7 +36,7 @@
             </form>
           </div>
         </div>
-        <form method="POST" action="/ajax/page/client.php" name="wpa_conf_form" class="live-form" data-modal-title="<?= _("Configuring WiFi Client"); ?>">
+        <form method="POST" action="/ajax/page/client.php" name="wpa_conf_form" class="live-form" data-modal-title="<?= _("Configuring WiFi Client"); ?>" inert>
           <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
           <div class="row" id="wpaConf">
             <div class="col position-relative">

--- a/templates/dhcp.php
+++ b/templates/dhcp.php
@@ -13,7 +13,7 @@
           <div>
             <i class="fas fa-exchange-alt me-2"></i><?php echo _("DHCP Server"); ?>
           </div>
-          <form method="POST" action="dhcpd_conf">
+          <form method="POST" action="/ajax/page/dhcpd.php" class="live-form" data-modal-title="<?= _("DNSMASQ Service Control") ?>">
             <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
             <div class="btn-group" role="group">
               <?php if (!RASPI_MONITOR_ENABLED) : ?>
@@ -41,7 +41,7 @@
 
       <div class="card-body">
         <?php $status->showMessages(); ?>
-        <form method="POST" action="dhcpd_conf" class="js-dhcp-settings-form needs-validation" novalidate>
+        <form method="POST" action="/ajax/page/dhcpd.php" class="js-dhcp-settings-form needs-validation live-form" novalidate data-modal-title="<?= _("DHCP Configuration") ?>">
           <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
 
           <!-- Nav tabs -->

--- a/templates/dhcp.php
+++ b/templates/dhcp.php
@@ -13,7 +13,7 @@
           <div>
             <i class="fas fa-exchange-alt me-2"></i><?php echo _("DHCP Server"); ?>
           </div>
-          <form method="POST" action="/ajax/page/dhcpd.php" class="live-form" data-modal-title="<?= _("DNSMASQ Service Control") ?>">
+          <form method="POST" action="/ajax/page/dhcpd.php" class="live-form" data-modal-title="<?= _("DNSMASQ Service Control") ?>" inert>
             <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
             <div class="btn-group" role="group">
               <?php if (!RASPI_MONITOR_ENABLED) : ?>
@@ -41,7 +41,7 @@
 
       <div class="card-body">
         <?php $status->showMessages(); ?>
-        <form method="POST" action="/ajax/page/dhcpd.php" class="js-dhcp-settings-form needs-validation live-form" novalidate data-modal-title="<?= _("DHCP Configuration") ?>">
+        <form method="POST" action="/ajax/page/dhcpd.php" class="js-dhcp-settings-form needs-validation live-form" novalidate data-modal-title="<?= _("DHCP Configuration") ?>" inert>
           <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
 
           <!-- Nav tabs -->

--- a/templates/hostapd.php
+++ b/templates/hostapd.php
@@ -14,19 +14,19 @@
             <i class="fas fa-bullseye me-2"></i><?php echo _("Hotspot"); ?>
           </div>
           <div>
-            <form method="POST" action="hostapd_conf">
+            <form method="POST" action="/ajax/page/hostapd.php" class="live-form" data-modal-title="<?php echo _("Hotspot Service Control") ?>">
               <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
               <div class="btn-group" role="group">
                 <?php if (!RASPI_MONITOR_ENABLED) : ?>
                   <?php if ($hostapdstatus[0] == 0) : ?>
-                    <button type="submit" class="btn btn-sm btn-light" title="<?php echo  _("Start hotspot"); $msg=_("Starting hotspot"); ?>" name="StartHotspot" data-bs-toggle="modal" data-bs-target="#hostapdModal">
+                    <button type="submit" class="btn btn-sm btn-light" title="<?php echo  _("Start hotspot"); ?>" name="StartHotspot">
                       <i class="fas fa-play"></i>
                     </button>
                   <?php else : ?>
                     <button type="submit" class="btn btn-sm btn-danger" title="<?php echo _("Stop hotspot") ?>" name="StopHotspot" >
                       <i class="fas fa-stop"></i>
                     </button>
-                    <button type="submit" class="btn btn-sm btn-warning" title="<?php echo _("Restart hotspot"); $msg=_("Restarting hotspot"); ?>" name="RestartHotspot" data-bs-toggle="modal" data-bs-target="#hostapdModal">
+                    <button type="submit" class="btn btn-sm btn-warning" title="<?php echo _("Restart hotspot"); ?>" name="RestartHotspot">
                       <i class="fas fa-sync-alt"></i>
                     </button>
                   <?php endif ?>
@@ -43,7 +43,7 @@
 
       <div class="card-body">
         <?php $status->showMessages(); ?>
-        <form role="form" action="hostapd_conf" method="POST" class="needs-validation" novalidate>
+        <form role="form" method="POST" action="/ajax/page/hostapd.php" class="needs-validation live-form" novalidate data-modal-title="<?php echo _("Hotspot Settings") ?>">
           <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
 
           <!-- Nav tabs -->
@@ -70,28 +70,8 @@
         </form>
       </div><!-- /.card-body -->
 
-      <div class="card-footer"> <?php echo _("Information provided by hostapd"); ?></div>
+      <div class="card-footer"><?php echo _("Information provided by hostapd"); ?></div>
 
     </div><!-- /.card -->
   </div><!-- /.col-lg-12 -->
 </div><!-- /.row -->
-
-<!-- Modal service-start -->
-<div class="modal fade" id="hostapdModal" tabindex="-1" role="dialog" aria-labelledby="ModalLabel" aria-hidden="true">
-  <div class="modal-dialog" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-        <div class="modal-title" id="ModalLabel"><i class="fas fa-sync-alt fa-spin me-2"></i><?php echo $msg ?></div>
-      </div>
-      <div class="modal-body">
-        <div class="col-md-12 mb-3 mt-1"><?php echo _("Executing RaspAP service start") ?>...</div>
-        <div class="progress" style="height: 20px;">
-          <div class="progress-bar bg-info" role="progressbar" id="progressBar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="9"></div>
-        </div>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-outline-primary" data-bs-dismiss="modal"><?php echo _("Close"); ?></button>
-      </div>
-    </div>
-  </div>
-</div>

--- a/templates/hostapd.php
+++ b/templates/hostapd.php
@@ -14,7 +14,7 @@
             <i class="fas fa-bullseye me-2"></i><?php echo _("Hotspot"); ?>
           </div>
           <div>
-            <form method="POST" action="/ajax/page/hostapd.php" class="live-form" data-modal-title="<?php echo _("Hotspot Service Control") ?>">
+            <form method="POST" action="/ajax/page/hostapd.php" class="live-form" data-modal-title="<?php echo _("Hotspot Service Control") ?>" inert>
               <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
               <div class="btn-group" role="group">
                 <?php if (!RASPI_MONITOR_ENABLED) : ?>
@@ -43,7 +43,7 @@
 
       <div class="card-body">
         <?php $status->showMessages(); ?>
-        <form role="form" method="POST" action="/ajax/page/hostapd.php" class="needs-validation live-form" novalidate data-modal-title="<?php echo _("Hotspot Settings") ?>">
+        <form role="form" method="POST" action="/ajax/page/hostapd.php" class="needs-validation live-form" novalidate data-modal-title="<?php echo _("Hotspot Settings") ?>" inert>
           <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
 
           <!-- Nav tabs -->

--- a/templates/openvpn.php
+++ b/templates/openvpn.php
@@ -13,32 +13,32 @@
           <div>
             <i class="fas fa-key fa-fw me-2"></i><?php echo _("OpenVPN"); ?>
           </div>
-          <form method="POST" action="openvpn_conf">
-              <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
-              <div class="btn-group" role="group">
-                <?php if (!RASPI_MONITOR_ENABLED) : ?>
-                  <?php if ($openvpnstatus[0] == 0) : ?>
-                    <button type="submit" class="btn btn-sm btn-light" title="<?php echo _("Start OpenVPN"); ?>" name="StartOpenVPN" >
-                      <i class="fas fa-play"></i>
-                    </button>
-                  <?php else : ?>
-                    <button type="submit" class="btn btn-sm btn-danger" title="<?php echo _("Stop OpenVPN"); ?>" name="StopOpenVPN" >
-                      <i class="fas fa-stop"></i>
-                    </button>
-                  <?php endif; ?>
-                <?php endif ?>
-                <button type="button" class="btn btn-light btn-icon-split btn-sm service-status float-end">
-                  <span class="icon text-gray-600"><i class="fas fa-circle service-status-<?php echo $serviceStatus ?>"></i></span>
-                  <span class="text service-status">openvpn <?php echo _($serviceStatus) ?></span>
-                </button>
-              </div>
+          <form method="POST" action="/ajax/page/openvpn.php" class="live-form" data-modal-title="<?php echo _("OpenVPN Service Control"); ?>">
+            <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
+            <div class="btn-group" role="group">
+              <?php if (!RASPI_MONITOR_ENABLED) : ?>
+                <?php if ($serviceStatus === 'down') : ?>
+                  <button type="submit" class="btn btn-sm btn-light" title="<?php echo _("Start OpenVPN"); ?>" name="StartOpenVPN" >
+                    <i class="fas fa-play"></i>
+                  </button>
+                <?php else : ?>
+                  <button type="submit" class="btn btn-sm btn-danger" title="<?php echo _("Stop OpenVPN"); ?>" name="StopOpenVPN" >
+                    <i class="fas fa-stop"></i>
+                  </button>
+                <?php endif; ?>
+              <?php endif ?>
+              <button type="button" class="btn btn-light btn-icon-split btn-sm service-status float-end">
+                <span class="icon text-gray-600"><i class="fas fa-circle service-status-<?php echo $serviceStatus ?>"></i></span>
+                <span class="text service-status">openvpn <?php echo _($serviceStatus) ?></span>
+              </button>
+            </div>
           </form>
         </div><!-- /.row -->
       </div><!-- /.card-header -->
       
       <div class="card-body">
         <?php $status->showMessages(); ?>
-        <form role="form" action="openvpn_conf" enctype="multipart/form-data" method="POST">
+        <form role="form" method="POST" action="/ajax/page/openvpn.php" enctype="multipart/form-data" class="live-form" data-modal-title="<?php echo _("OpenVPN Configuration"); ?>">
           <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
           <!-- Nav tabs -->
           <ul class="nav nav-tabs">

--- a/templates/openvpn.php
+++ b/templates/openvpn.php
@@ -13,7 +13,7 @@
           <div>
             <i class="fas fa-key fa-fw me-2"></i><?php echo _("OpenVPN"); ?>
           </div>
-          <form method="POST" action="/ajax/page/openvpn.php" class="live-form" data-modal-title="<?php echo _("OpenVPN Service Control"); ?>">
+          <form method="POST" action="/ajax/page/openvpn.php" class="live-form" data-modal-title="<?php echo _("OpenVPN Service Control"); ?>" inert>
             <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
             <div class="btn-group" role="group">
               <?php if (!RASPI_MONITOR_ENABLED) : ?>
@@ -38,7 +38,7 @@
       
       <div class="card-body">
         <?php $status->showMessages(); ?>
-        <form role="form" method="POST" action="/ajax/page/openvpn.php" enctype="multipart/form-data" class="live-form" data-modal-title="<?php echo _("OpenVPN Configuration"); ?>">
+        <form role="form" method="POST" action="/ajax/page/openvpn.php" enctype="multipart/form-data" class="live-form" data-modal-title="<?php echo _("OpenVPN Configuration"); ?>" inert>
           <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
           <!-- Nav tabs -->
           <ul class="nav nav-tabs">

--- a/templates/wg/general.php
+++ b/templates/wg/general.php
@@ -33,8 +33,7 @@
 
                 <div class="mb-3">
                   <div class="form-check form-switch">
-                    <?php $checked = $optRules == 1 ? 'checked="checked"' : '' ?>
-                    <input class="form-check-input" id="chxwgrules" name="wgRules" type="checkbox" value="1" <?php echo $checked ?> />
+                    <input class="form-check-input" id="chxwgrules" name="wgRules" type="checkbox" value="1" />
                     <label class="form-check-label" for="chxwgrules"><?php echo _("Apply iptables rules to the selected interface"); ?></label>
                     <i class="fas fa-question-circle text-muted" data-bs-toggle="tooltip" data-bs-placement="auto" title="<?php echo _("Recommended if you wish to forward network traffic from the wg0 interface to clients connected on a desired interface. The active AP interface is the default."); ?>"></i>
                     <p id="wg-description">
@@ -45,8 +44,7 @@
                       </div>
                   </div>
                   <div class="form-check form-switch">
-                    <?php $checked = $optKSwitch == 1 ? 'checked="checked"' : '' ?>
-                    <input class="form-check-input" id="chxwgkswitch" name="wgKSwitch" type="checkbox" value="1" <?php echo $checked ?> />
+                    <input class="form-check-input" id="chxwgkswitch" name="wgKSwitch" type="checkbox" value="1" />
                     <label class="form-check-label" for="chxwgkswitch"><?php echo _("Enable kill switch"); ?></label>
                     <i class="fas fa-question-circle text-muted" data-bs-toggle="tooltip" data-bs-placement="auto" title="<?php echo _("Recommended if you wish to prevent the flow of unencrypted packets through non-WireGuard interfaces."); ?>"></i>
                     <p id="wg-description">

--- a/templates/wifi_stations/network.php
+++ b/templates/wifi_stations/network.php
@@ -87,17 +87,17 @@ $network['passphrase'] = $network['passphrase'] ?? '';
 
         <div class="btn-group btn-block d-flex">
             <?php if ($network['configured']) { ?>
-                <input type="submit" class="btn btn-warning" value="<?php echo _("Update"); ?>" id="update<?php echo $index ?>" name="update<?php echo $index ?>"<?php echo ($network['protocol'] === 'Open' ? ' disabled' : '')?> data-bs-toggle="modal" data-bs-target="#configureClientModal" />
+                <input type="submit" class="btn btn-warning" value="<?php echo _("Update"); ?>" id="update<?php echo $index ?>" name="update<?php echo $index ?>"<?php echo ($network['protocol'] === 'Open' ? ' disabled' : '')?> />
                 <?php if ($network['connected']) { ?>
                     <button type="submit" class="btn btn-info" value="<?php echo $index?>" name="disconnect<?php echo $index ?>"><?php echo _("Disconnect"); ?></button>
                 <?php } else { ?>
                     <button type="submit" class="btn btn-info" value="<?php echo $index?>" name="connect"><?php echo _("Connect"); ?></button>
                 <?php } ?>
             <?php } else { ?>
-                <input type="submit" class="btn btn-info" value="<?php echo _("Add"); ?>" id="update<?php echo $index ?>" name="update<?php echo $index ?>" data-bs-toggle="modal" data-bs-target="#configureClientModal" />
+                <input type="submit" class="btn btn-info" value="<?php echo _("Add"); ?>" id="update<?php echo $index ?>" name="update<?php echo $index ?>" />
             <?php } ?>
 			<?php if ($network['configured']) { ?>
-            	<input type="submit" class="btn btn-danger" value="<?php echo _("Delete"); ?>" name="delete<?php echo $index ?>" data-bs-toggle="modal" data-bs-target="#configureClientModal" />
+            	<input type="submit" class="btn btn-danger" value="<?php echo _("Delete"); ?>" name="delete<?php echo $index ?>" />
 			<?php } ?>		
 		</div><!-- /.btn-group -->
 	</div><!-- /.card-body -->

--- a/templates/wireguard.php
+++ b/templates/wireguard.php
@@ -13,16 +13,16 @@
           <div>
             <span class="ra-wireguard me-2"></span><?php echo _("WireGuard"); ?>
           </div>
-          <form method="POST" action="wg_conf">
+          <form method="POST" action="/ajax/page/wireguard.php" class="live-form" data-modal-title="<?= _('WireGuard Service Control') ?>">
             <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
             <div class="btn-group" role="group">
               <?php if (!RASPI_MONITOR_ENABLED) : ?>
                 <?php if ($wg_state) : ?>
-                  <button type="submit" class="btn btn-sm btn-danger" title="<?php echo _("Stop WireGuard"); ?>" name="stopwg" >
+                  <button type="submit" class="btn btn-sm btn-danger" title="<?php echo _("Stop WireGuard"); ?>" name="stopwg">
                     <i class="fas fa-stop"></i>
                   </button>
                 <?php else : ?>
-                  <button type="submit" class="btn btn-sm btn-light" title="<?php echo _("Start WireGuard"); ?>" name="startwg" >
+                  <button type="submit" class="btn btn-sm btn-light" title="<?php echo _("Start WireGuard"); ?>" name="startwg">
                     <i class="fas fa-play"></i>
                   </button>
                 <?php endif; ?>
@@ -38,7 +38,7 @@
 
       <div class="card-body">
         <?php $status->showMessages(); ?>
-        <form role="form" action="wg_conf" enctype="multipart/form-data" method="POST">
+        <form role="form" method="POST" action="/ajax/page/wireguard.php" enctype="multipart/form-data" class="live-form" data-modal-title="<?= _('WireGuard Configuration') ?>">
           <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
           <!-- Nav tabs -->
           <ul class="nav nav-tabs">

--- a/templates/wireguard.php
+++ b/templates/wireguard.php
@@ -13,7 +13,7 @@
           <div>
             <span class="ra-wireguard me-2"></span><?php echo _("WireGuard"); ?>
           </div>
-          <form method="POST" action="/ajax/page/wireguard.php" class="live-form" data-modal-title="<?= _('WireGuard Service Control') ?>">
+          <form method="POST" action="/ajax/page/wireguard.php" class="live-form" data-modal-title="<?= _('WireGuard Service Control') ?>" inert>
             <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
             <div class="btn-group" role="group">
               <?php if (!RASPI_MONITOR_ENABLED) : ?>
@@ -38,7 +38,7 @@
 
       <div class="card-body">
         <?php $status->showMessages(); ?>
-        <form role="form" method="POST" action="/ajax/page/wireguard.php" enctype="multipart/form-data" class="live-form" data-modal-title="<?= _('WireGuard Configuration') ?>">
+        <form role="form" method="POST" action="/ajax/page/wireguard.php" enctype="multipart/form-data" class="live-form" data-modal-title="<?= _('WireGuard Configuration') ?>" inert>
           <?php echo \RaspAP\Tokens\CSRF::hiddenField(); ?>
           <!-- Nav tabs -->
           <ul class="nav nav-tabs">


### PR DESCRIPTION
This PR address a few oddities of the UI/UX mentioned in #2101 by introducing form submission with live updates. Its function is described below.

## Backend
The backend has a new class `LiveForm` that contains reusable code to be able to create the stream of information to be used by the front end.

There are a few functions in the `LiveFrom` class that have important purposes.
- `initAjax()` - Should be run at the start of the file to set important headers and required settings for a successful stream.
- `sendStartMessage()` - Sends a message to the frontend to be handled by code that the stream is starting.
- `sendCompleteMessage()` - Sends a message to the frontend to be handled by code that the stream is complete and the page should refresh.
-  `sendFailedMessage()` - Sends a message to the frontend to be handled by code that something in the submission had a critical error and did not finish what was inteneded.
- `sendUpdateMessage()` - Sends a message to the frontend with text to show the user as well as an optional update of the percentage the progress bar should show.
- `saveStatusMessage()` - Saves a status message to show when the page reloads. Ideally should only be run once at the end of each logic flow. This function has an option to show a collapsable history that shows the messages sent.

When converting forms to use live form submisison certain functions may still use the old `StatusMessage` class to give updates. To get around rewriting everything a helper class `LiveFormStatusMessage` exists to pass to necessary functions and forward the message as a live update instead of a standard bootstrap alert on page load.

In the page's builder file (often in `includes`) be sure to run the static function `loadStatusMessages()` to pull the saved status messages from the session and add them to the page's `$status` messages.

## Frontend
Note: Images shown may not reflect final look

To have a form use live form submission, add the class `.live-form` to the form element. If bootstrap validation is needed it will run before the live form submission is run. Set the action to a new ajax file to process the submitted form.

### Live Update Modal
The modal contains a dynamic progress bar and the most update message. Below it is a collapsable scrollable history of messages sent. The modal is configured so that it cannot be hidden or dismissed.

<img width="514" height="316" alt="Screenshot 2026-04-24 at 5 11 50 PM" src="https://github.com/user-attachments/assets/1c705d75-9e21-4346-bfa6-6c641dfdc61e" />

#### Modal Options
- `data-modal-title` - Can be applied to either the `form` or the submitting button if there are multiple buttons to submit the same form with different outcomes.

### Refreshed Page Alert with Details
Once the live form submission stream receives the complete message it will refresh the page. Assuming `loadStatusMessages()` is called any saved status messages will be shown. If the status message was configured to show the message history it will have a collapsible details button.

<img width="812" height="362" alt="Screenshot 2026-04-24 at 2 08 58 PM" src="https://github.com/user-attachments/assets/0deaee68-ea8e-41cf-895d-337df813fac8" />

## Implementing
This isn't something that necessarily needs to be used on all form submissions, but is useful for transparency to the user on what is happening.

Forms converted:
- [x] Hotspot
- [x] DHCP
- [x] AdBlock
- [x] WiFI Client
- [x] OpenVPN
- [x] WireGuard
- [ ] Update Check?
- Comment any others that should be converted

## Issues
- ~~Stream will be shown when form is submitted before JS is loaded~~
- ~~Frontend feedback when ajax fails~~
- ~~Backend handling of php error to send failed message~~

## Bug Fixes
- Add `use function` statements to give more clear error messages when global functions aren't `require_once`
  - `DhcpcdManager.php`
  - `DnsmasqManager.php`
  - `WiFiManager.php`
  - `HostapdManager.php`
  - `HotspotService.php`
- Add `$this` for `getIfaceMetric()` function call in `DhcpcdManager.php`
