### PR TITLE
Feature: Extended user theme customization support

### DIFF
--- a/app/css/base.css
+++ b/app/css/base.css
@@ -7,7 +7,7 @@ License: GNU General Public License v3.0
 */
 
 :root {
-  --raspap-brand-color: #2b8080;
+  --raspap-theme-color: #2b8080;
   --raspap-content-main: #495057;
   --raspap-text-muted: #858796;
   --raspap-text-light: #999999;
@@ -21,8 +21,8 @@ body {
 
 /* Typography */
 a {
-  --bs-link-color: var(--raspap-brand-color);
-  --bs-link-hover-color: var(--raspap-brand-color);
+  --bs-link-color: var(--raspap-theme-color);
+  --bs-link-hover-color: var(--raspap-theme-color);
   text-decoration: none;
 }
 
@@ -172,10 +172,10 @@ button.btn i:not([class*="service-status"]) {
 
 .sb-sidenav .sb-nav-link-icon.active .nav-link {
   font-weight: bolder;
-  color: var(--raspap-brand-color);
+  color: var(--raspap-theme-color);
 }
 .sb-sidenav .sb-nav-link-icon.active i.sb-nav-link-icon {
-  color: var(--raspap-brand-color);
+  color: var(--raspap-theme-color);
 }
 
 .sidebar-brand-text {
@@ -195,17 +195,29 @@ button.btn i:not([class*="service-status"]) {
   margin-left: 0.7em;
 }
 
+.navbar-logo-icon {
+  display: inline-block;
+  margin-top: 0.1em;
+  margin-left: 0.1em;
+  line-height: 1;
+}
+
 #navbar-system-mode {
   color: var(--raspap-text-muted);
 }
 #navbar-system-mode.active {
-  color: var(--raspap-brand-color);
+  color: var(--raspap-theme-color);
 }
 
 .login-logo {
   width: 70px;
   height: 70px;
   margin-left: 1.2rem;
+  margin-bottom: -0.5rem;
+}
+
+.login-logo-icon {
+  display: inline-block;
   margin-bottom: -0.5rem;
 }
 
@@ -326,7 +338,14 @@ button.btn i:not([class*="service-status"]) {
 
 /* Login */
 #modal-admin-login .modal-content {
-  background: radial-gradient(circle at 120% -20%, #032626, #052c2c, #073232, #0a3838, #0d3f3f, #114545, #144c4c);
+  background: radial-gradient(circle at 120% -20%,
+    color-mix(in srgb, var(--raspap-theme-color) 30%, black),
+    color-mix(in srgb, var(--raspap-theme-color) 36%, black),
+    color-mix(in srgb, var(--raspap-theme-color) 42%, black),
+    color-mix(in srgb, var(--raspap-theme-color) 48%, black),
+    color-mix(in srgb, var(--raspap-theme-color) 54%, black),
+    color-mix(in srgb, var(--raspap-theme-color) 60%, black),
+    color-mix(in srgb, var(--raspap-theme-color) 66%, black));
   align-items: center;
 }
 
@@ -335,7 +354,7 @@ button.btn i:not([class*="service-status"]) {
 }
 
 .login-brand {
-  color: var(--raspap-brand-color);
+  color: var(--raspap-theme-color);
   filter: brightness(150%);
 }
 
@@ -346,7 +365,7 @@ button.btn i:not([class*="service-status"]) {
 
 .btn-admin-login {
   color: var(--raspap-offwhite);
-  background-color: var(--raspap-brand-color);
+  background-color: var(--raspap-theme-color);
 }
 
 .btn-admin-login:hover {
@@ -453,11 +472,11 @@ button.btn i:not([class*="service-status"]) {
   transition: background 0.15s linear;
   background: transparent;
   font-weight: 600;
-  color: var(--raspap-brand-color);
+  color: var(--raspap-theme-color);
   border: none;
 }
 .ip-info-toggle button.active {
-  background: var(--raspap-brand-color);
+  background: var(--raspap-theme-color);
   color: white;
 }
 
@@ -626,19 +645,19 @@ a.inactive:focus {
 
 .client-type i {
   font-size: 1.5rem;
-  /* color: var(--raspap-brand-color); */
+  /* color: var(--raspap-theme-color); */
   width: 45px;
   height: 45px;
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 2px solid var(--raspap-brand-color);
+  border: 2px solid var(--raspap-theme-color);
 }
 
 .client-type i.badge-icon {
   font-size: 0.7rem;
-  background: var(--raspap-brand-color);
+  background: var(--raspap-theme-color);
   color: var(--raspap-offwhite);
   width: 20px;
   height: 20px;
@@ -649,7 +668,7 @@ a.inactive:focus {
   position: absolute;
   top: -5px;
   right: -5px;
-  background: var(--raspap-brand-color);
+  background: var(--raspap-theme-color);
   color: var(--raspap-offwhite);
   border-radius: 50%;
   width: 20px;

--- a/app/css/themes/default.php
+++ b/app/css/themes/default.php
@@ -1,5 +1,6 @@
 <?php header("Content-Type: text/css;charset=utf-8"); ?>
 <?php
+    require_once '../../../includes/config.php';
     require_once '../../../includes/functions.php';
     $color = getColorOpt();
 ?>

--- a/app/js/vendor/huebee.js
+++ b/app/js/vendor/huebee.js
@@ -21,10 +21,9 @@ var hueb = new Huebee( elem, {
     hue0: 210
 });
 
-// Set custom color if defined
 var color = getCookie('color');
 if (color == null || color == '') {
-    color = '#2b8080';
+    color = elem.value || '#2b8080';
 }
 hueb.setColor(color);
 

--- a/config/config.php
+++ b/config/config.php
@@ -2,6 +2,8 @@
 
 define('RASPI_BRAND_TEXT', 'RaspAP');
 define('RASPI_BRAND_TITLE', RASPI_BRAND_TEXT.' Admin Panel');
+define('RASPI_BRAND_ICON', '');
+define('RASPI_BRAND_COLOR', '#2b8080');
 define('RASPI_CONFIG', '/etc/raspap');
 define('RASPI_CONFIG_NETWORK', RASPI_CONFIG.'/networking/defaults.json');
 define('RASPI_CONFIG_PROVIDERS', 'config/vpn-providers.json');

--- a/includes/defaults.php
+++ b/includes/defaults.php
@@ -7,6 +7,8 @@ if (!defined('RASPI_CONFIG')) {
 $defaults = [
     'RASPI_BRAND_TEXT' => 'RaspAP',
     'RASPI_BRAND_TITLE' => RASPI_BRAND_TEXT.' Admin Panel',
+    'RASPI_BRAND_ICON' => '',
+    'RASPI_BRAND_COLOR' => '#2b8080',
     'RASPI_VERSION' => '3.5.5',
     'RASPI_CONFIG_NETWORK' => RASPI_CONFIG.'/networking/defaults.json',
     'RASPI_CONFIG_PROVIDERS' => 'config/vpn-providers.json',

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -591,27 +591,52 @@ function getThemeOpt()
 
 function getColorOpt()
 {
+    $defaultColor = defined('RASPI_BRAND_COLOR') ? RASPI_BRAND_COLOR : '#2b8080';
+
     if (!isset($_COOKIE['color'])) {
-        $color = "#2b8080";
+        $color = $defaultColor;
     } else {
         $color = $_COOKIE['color'];
     }
 
     // Define the regex pattern for valid CSS color formats
     $colorPattern = "/^(" .
-        "#([a-fA-F0-9]{3}|[a-fA-F0-9]{6})" . "|" .           // Hex colors (#RGB or #RRGGBB)
-        "rgb\(\s*(?:\d{1,3}\s*,\s*){2}\d{1,3}\s*\)" . "|" .     // RGB format
-        "rgba\(\s*(?:\d{1,3}\s*,\s*){3}\s*(0|0\.\d+|1)\s*\)" . "|" . // RGBA format
-        "[a-zA-Z]+" .                                         // Named colors
+        "#([a-fA-F0-9]{3}|[a-fA-F0-9]{6})" . "|" .           	// hex colors
+        "rgb\(\s*(?:\d{1,3}\s*,\s*){2}\d{1,3}\s*\)" . "|" .     // RGB
+        "rgba\(\s*(?:\d{1,3}\s*,\s*){3}\s*(0|0\.\d+|1)\s*\)" . "|" . // RGBA
+        "[a-zA-Z]+" .                                         	// named colors
     ")$/i";
 
-    // Validate the color
     if (!preg_match($colorPattern, $color)) {
-        // Return a default color if validation fails
-        $color = "#2b8080";
+        // return default color if not valid
+        $color = $defaultColor;
     }
 
     return $color;
+}
+
+/**
+ * Renders brand icon (navbar, sidebar + login page)
+ * Set with RASPI_BRAND_ICON in config.php
+ */
+function renderBrandIcon($width = 70, $height = 70, $class = 'navbar-logo', $static = true)
+{
+    $icon = defined('RASPI_BRAND_ICON') ? trim(RASPI_BRAND_ICON) : '';
+    $class = htmlspecialchars($class, ENT_QUOTES, 'UTF-8');
+
+    if ($icon === '') {
+        $query = $static ? '?static=1' : '';
+        echo '<img src="app/img/raspAP-logo.php'.$query.'" class="'.$class.'" width="'.(int)$width.'" height="'.(int)$height.'">';
+        return;
+    }
+
+    // FontAwesome icon classes
+    if (preg_match('/^(fa[srlbdk]?|fa-\w+)\s+fa-[\w-]+/', $icon)) {
+        echo '<i class="'.htmlspecialchars($icon, ENT_QUOTES, 'UTF-8').' '.$class.'-icon" style="font-size: '.(int)$height.'px; color: var(--raspap-theme-color);"></i>';
+        return;
+    }
+
+    echo '<img src="'.htmlspecialchars($icon, ENT_QUOTES, 'UTF-8').'" class="'.$class.'" width="'.(int)$width.'" height="'.(int)$height.'">';
 }
 
 function getBridgedState()
@@ -923,7 +948,7 @@ function renderStatus($hostapd_led, $hostapd_status, $memused_led, $memused, $cp
     ?>
     <div class="row g-0">
       <div class="col-4 ms-2 sidebar-brand-icon">
-        <img src="app/img/raspAP-logo.php?static=1" class="navbar-logo" width="70" height="70">
+        <?php renderBrandIcon(70, 70, 'navbar-logo'); ?>
       </div>
       <div class="col ml-2">
         <div class="ml-1 sb-status"><?php echo _("Status"); ?></div>

--- a/includes/navbar.php
+++ b/includes/navbar.php
@@ -1,6 +1,6 @@
 <nav class="sb-topnav navbar navbar-expand navbar-light bg-light">
   <!-- Navbar Brand-->
-  <a class="sidebar-brand-text navbar-brand ps-3" href="/">RaspAP</a>
+  <a class="sidebar-brand-text navbar-brand ps-3" href="/"><?php echo htmlspecialchars(RASPI_BRAND_TEXT); ?></a>
   <!-- Sidebar Toggle-->
   <button class="btn btn-link btn-lg order-1 order-lg-0 me-lg-auto py-2 px-3 bd-highlight" id="sidebarToggle" href="#!">
     <i class="fas fa-bars"></i>

--- a/index.php
+++ b/index.php
@@ -88,7 +88,7 @@ initializeApp();
     <!-- Custom CSS -->
     <link href="app/css/base.css?v=<?= filemtime('app/css/base.css'); ?>" rel="stylesheet" />
     <link href="<?php echo $_SESSION['theme']['url'] . "?v=" . filemtime($_SESSION['theme']['url']); ?>" title="main" rel="stylesheet">
-    
+
     <!-- Meta -->
     <link rel="icon" type="image/png" href="/app/icons/favicon-96x96.png" sizes="96x96" />
     <link rel="icon" type="image/svg+xml" href="/app/icons/favicon.svg" />

--- a/templates/login.php
+++ b/templates/login.php
@@ -8,7 +8,7 @@
           <div class="col-12">
             <!-- branding -->
             <div class="text-center mb-3">
-              <img src="app/img/raspAP-logo.php" class="login-logo" alt="RaspAP logo" class="img-fluid" style="max-width: 100px;">
+              <?php renderBrandIcon(70, 70, 'login-logo', false); ?>
               <h2 class="login-brand"><?php echo htmlspecialchars(RASPI_BRAND_TEXT); ?></h2>
               <div class="mt-2 admin-login"><?php echo _("Administrator login") ?></div>
               <div class="text-center text-danger mt-1 mb-3"><?php echo $status ?></div>

--- a/templates/system/theme.php
+++ b/templates/system/theme.php
@@ -10,7 +10,7 @@
       </div>
       <div class="col-sm-6 col-md-3 mb-3">
         <label for="code"><?php echo _("Color"); ?></label>
-        <input class="form-control color-input" value="#2b8080" aria-label="color" />
+        <input class="form-control color-input" value="<?php echo htmlspecialchars(getColorOpt(), ENT_QUOTES); ?>" aria-label="color" />
       </div>
     </div>
     <div class="row">


### PR DESCRIPTION
This adds two new settings to `config.php` to enable dynamic theme customization.

```
define('RASPI_BRAND_ICON', '');
define('RASPI_BRAND_COLOR', '#2b8080');
```

For example, a Switchberry theme may be applied simply by adding the following:
```
define('RASPI_BRAND_TEXT', 'Switchberry');
define('RASPI_BRAND_ICON', 'fas fa-clock');
define('RASPI_BRAND_COLOR', '#df7618');
```

This renders a gradient background and form elements on the login template from a single color value:

<img width="1218" height="771" alt="Switchberry login" src="https://github.com/user-attachments/assets/c39f26cc-771d-4a6f-8144-e1ae4b089f42" />

The remaining templates are themed with the selected fa icon and brand color:

<img width="493" height="342" alt="themed templates" src="https://github.com/user-attachments/assets/438b3de5-a40c-4841-82a0-e017e9e6e426" />

